### PR TITLE
Anvil set chain

### DIFF
--- a/src/fork.rs
+++ b/src/fork.rs
@@ -351,6 +351,13 @@ impl<S> ForkStorage<S> {
         let mut mutator = self.inner.write().unwrap();
         mutator.raw_storage.store_factory_dep(hash, bytecode)
     }
+    pub fn set_chain_id(&mut self, id: L2ChainId) {
+        self.chain_id = id;
+        let mut mutator = self.inner.write().unwrap();
+        if let Some(fork) = &mut mutator.fork {
+            fork.set_chain_id(id)
+        }
+    }
 }
 
 /// Trait that provides necessary data when
@@ -775,6 +782,12 @@ impl ForkDetails {
     /// Sets fork's internal URL. Assumes the underlying chain is the same as before.
     pub fn set_rpc_url(&mut self, url: String) {
         self.fork_source = Box::new(HttpForkSource::new(url, self.cache_config.clone()));
+    }
+
+    // Sets fork's chain id.
+    pub fn set_chain_id(&mut self, id: L2ChainId) {
+        self.chain_id = id;
+        self.overwrite_chain_id = Some(id);
     }
 }
 

--- a/src/namespaces/anvil.rs
+++ b/src/namespaces/anvil.rs
@@ -310,6 +310,14 @@ pub trait AnvilNamespaceT {
     /// A `BoxFuture` containing a `Result` with a `bool` representing the success of the operation.
     #[rpc(name = "anvil_setStorageAt")]
     fn set_storage_at(&self, address: Address, slot: U256, value: U256) -> RpcResult<bool>;
+
+    /// Sets the chain id.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - The chain id to be set.
+    #[rpc(name = "anvil_setChainId")]
+    fn set_chain_id(&self, id: u32) -> RpcResult<()>;
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]

--- a/src/node/anvil.rs
+++ b/src/node/anvil.rs
@@ -257,4 +257,13 @@ impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> AnvilNames
             })
             .into_boxed_future()
     }
+
+    fn set_chain_id(&self, id: u32) -> RpcResult<()> {
+        self.set_chain_id(id)
+            .map_err(|err| {
+                tracing::error!("failed setting chain id: {:?}", err);
+                into_jsrpc_error(Web3Error::InternalError(err))
+            })
+            .into_boxed_future()
+    }
 }

--- a/src/node/in_memory_ext.rs
+++ b/src/node/in_memory_ext.rs
@@ -479,6 +479,16 @@ impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> InMemoryNo
         }
         Ok(())
     }
+
+    pub fn set_chain_id(&self, id: u32) -> Result<()> {
+        let mut inner =  self.inner
+            .write()
+            .map_err(|_| anyhow::anyhow!("Failed to acquire write lock"))?;
+
+        inner.config.update_chain_id(Some(id));
+        inner.fork_storage.set_chain_id(id.into());
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/src/node/in_memory_ext.rs
+++ b/src/node/in_memory_ext.rs
@@ -503,7 +503,7 @@ mod tests {
     use std::sync::{Arc, RwLock};
     use zksync_multivm::interface::storage::ReadStorage;
     use zksync_types::{api::BlockNumber, fee::Fee, l2::L2Tx, PackedEthSignature};
-    use zksync_types::{Nonce, H256};
+    use zksync_types::{Nonce, H256, L2ChainId};
     use zksync_utils::h256_to_u256;
 
     #[tokio::test]
@@ -1076,5 +1076,17 @@ mod tests {
 
         let result = node.revert_snapshot(U64::from(100));
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_node_set_chain_id() {
+        let node = InMemoryNode::<HttpForkSource>::default();
+        let new_chain_id = 261;
+
+        let _ = node.set_chain_id(new_chain_id);
+
+        let node_inner =  node.inner.read().unwrap();
+        assert_eq!(new_chain_id, node_inner.config.chain_id.unwrap());
+        assert_eq!(L2ChainId::from(new_chain_id), node_inner.fork_storage.chain_id);
     }
 }


### PR DESCRIPTION
# What :computer: 
- Added `anvil_setChainId` API.

# Why :hand:
- Feature parity with anvil.
