### PR TITLE
feat: fees transactions order in mempool

### DIFF
--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -252,7 +252,7 @@ pub struct Cli {
     #[arg(long, default_missing_value = "true", num_args(0..=1), conflicts_with = "allow_origin", help_heading = "Server options")]
     pub no_cors: Option<bool>,
 
-    /// How transactions are sorted in the mempool.
+    /// Transaction ordering in the mempool.
     #[arg(long, default_value = "fifo")]
     pub order: TransactionOrder,
 }
@@ -396,7 +396,7 @@ impl Cli {
             .with_no_mining(self.no_mining)
             .with_allow_origin(self.allow_origin)
             .with_no_cors(self.no_cors)
-            .with_transactions_order(self.order);
+            .with_transaction_order(self.order);
 
         if self.emulate_evm && self.dev_system_contracts != Some(SystemContractsOptions::Local) {
             return Err(eyre::eyre!(

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -253,7 +253,7 @@ pub struct Cli {
     pub no_cors: Option<bool>,
 
     /// How transactions are sorted in the mempool.
-    #[arg(long, default_value = "fees")]
+    #[arg(long, default_value = "fifo")]
     pub order: TransactionOrder,
 }
 

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -7,7 +7,7 @@ use anvil_zksync_config::types::{
     AccountGenerator, CacheConfig, CacheType, Genesis, LogLevel, ShowCalls, ShowGasDetails,
     ShowStorageLogs, ShowVMDetails, SystemContractsOptions,
 };
-use anvil_zksync_config::TestNodeConfig;
+use anvil_zksync_config::{types::TransactionOrder, TestNodeConfig};
 use clap::{arg, command, Parser, Subcommand};
 use rand::{rngs::StdRng, SeedableRng};
 use std::env;
@@ -243,6 +243,10 @@ pub struct Cli {
     /// Disable auto and interval mining, and mine on demand instead.
     #[arg(long, visible_alias = "no-mine", conflicts_with = "block_time")]
     pub no_mining: bool,
+
+    /// How transactions are sorted in the mempool.
+    #[arg(long, default_value = "fees")]
+    pub order: TransactionOrder,
 }
 
 #[derive(Debug, Subcommand, Clone)]
@@ -381,7 +385,8 @@ impl Cli {
                 None
             })
             .with_block_time(self.block_time)
-            .with_no_mining(self.no_mining);
+            .with_no_mining(self.no_mining)
+            .with_transactions_order(self.order);
 
         if self.emulate_evm && self.dev_system_contracts != Some(SystemContractsOptions::Local) {
             return Err(eyre::eyre!(

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -270,7 +270,7 @@ async fn main() -> anyhow::Result<()> {
 
     let time = TimestampManager::default();
     let impersonation = ImpersonationManager::default();
-    let pool = TxPool::new(impersonation.clone());
+    let pool = TxPool::new(impersonation.clone(), config.transactions_order);
     let sealing_mode = if config.no_mining {
         BlockSealerMode::noop()
     } else if let Some(block_time) = config.block_time {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -276,7 +276,7 @@ async fn main() -> anyhow::Result<()> {
 
     let time = TimestampManager::default();
     let impersonation = ImpersonationManager::default();
-    let pool = TxPool::new(impersonation.clone(), config.transactions_order);
+    let pool = TxPool::new(impersonation.clone(), config.transaction_order);
     let sealing_mode = if config.no_mining {
         BlockSealerMode::noop()
     } else if let Some(block_time) = config.block_time {

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -111,6 +111,8 @@ pub struct TestNodeConfig {
     pub max_transactions: usize,
     /// Disable automatic sealing mode and use `BlockSealer::Noop` instead
     pub no_mining: bool,
+    /// How transactions are sorted in the mempool
+    pub transactions_order: TransactionOrder,
 }
 
 impl Default for TestNodeConfig {
@@ -171,6 +173,7 @@ impl Default for TestNodeConfig {
             no_mining: false,
 
             max_transactions: 1000,
+            transactions_order: TransactionOrder::Fees,
         }
     }
 }
@@ -867,6 +870,12 @@ impl TestNodeConfig {
     #[must_use]
     pub fn with_no_mining(mut self, no_mining: bool) -> Self {
         self.no_mining = no_mining;
+        self
+    }
+    // Set transactions order in the mempool
+    #[must_use]
+    pub fn with_transactions_order(mut self, transactions_order: TransactionOrder) -> Self {
+        self.transactions_order = transactions_order;
         self
     }
 }

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -116,7 +116,7 @@ pub struct TestNodeConfig {
     /// Disable CORS if true
     pub no_cors: bool,
     /// How transactions are sorted in the mempool
-    pub transactions_order: TransactionOrder,
+    pub transaction_order: TransactionOrder,
 }
 
 impl Default for TestNodeConfig {
@@ -177,7 +177,7 @@ impl Default for TestNodeConfig {
             no_mining: false,
 
             max_transactions: 1000,
-            transactions_order: TransactionOrder::Fifo,
+            transaction_order: TransactionOrder::Fifo,
 
             // Server configuration
             allow_origin: "*".to_string(),
@@ -883,8 +883,8 @@ impl TestNodeConfig {
 
     // Set transactions order in the mempool
     #[must_use]
-    pub fn with_transactions_order(mut self, transactions_order: TransactionOrder) -> Self {
-        self.transactions_order = transactions_order;
+    pub fn with_transaction_order(mut self, transaction_order: TransactionOrder) -> Self {
+        self.transaction_order = transaction_order;
         self
     }
 

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -177,7 +177,7 @@ impl Default for TestNodeConfig {
             no_mining: false,
 
             max_transactions: 1000,
-            transactions_order: TransactionOrder::Fees,
+            transactions_order: TransactionOrder::Fifo,
 
             // Server configuration
             allow_origin: "*".to_string(),

--- a/crates/config/src/types/mod.rs
+++ b/crates/config/src/types/mod.rs
@@ -3,6 +3,7 @@ mod cache;
 mod genesis;
 mod log;
 mod show_details;
+mod transaction_order;
 
 pub use account_generator::AccountGenerator;
 pub use cache::{CacheConfig, CacheType};
@@ -11,6 +12,7 @@ pub use genesis::Genesis;
 pub use log::LogLevel;
 use serde::Deserialize;
 pub use show_details::{ShowCalls, ShowGasDetails, ShowStorageLogs, ShowVMDetails};
+pub use transaction_order::{TransactionOrder, TransactionPriority};
 
 #[derive(Deserialize, Default, Debug, Copy, Clone, PartialEq, ValueEnum)]
 pub enum SystemContractsOptions {

--- a/crates/config/src/types/transaction_order.rs
+++ b/crates/config/src/types/transaction_order.rs
@@ -1,0 +1,57 @@
+use std::fmt;
+use std::str::FromStr;
+use zksync_types::{l2::L2Tx, U256};
+
+/// Metric value for the priority of a transaction.
+///
+/// The `TransactionPriority` determines the ordering of two transactions.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub struct TransactionPriority(pub U256);
+
+/// Modes that determine the transaction ordering of the mempool
+///
+/// This type controls the transaction order via the priority metric of a transaction
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum TransactionOrder {
+    /// Keep the pool transactions sorted in the order they arrive.
+    ///
+    /// This will essentially assign every transaction the exact priority so the order is
+    /// determined by their internal submission number
+    Fifo,
+    /// This means that it prioritizes transactions based on the fees paid to the miner.
+    #[default]
+    Fees,
+}
+
+impl TransactionOrder {
+    /// Returns the priority of the transactions
+    pub fn priority(&self, tx: &L2Tx) -> TransactionPriority {
+        match self {
+            Self::Fifo => TransactionPriority::default(),
+            Self::Fees => TransactionPriority(tx.common_data.fee.max_fee_per_gas),
+        }
+    }
+}
+
+impl FromStr for TransactionOrder {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.to_lowercase();
+        let order = match s.as_str() {
+            "fees" => Self::Fees,
+            "fifo" => Self::Fifo,
+            _ => return Err(format!("Unknown TransactionOrder: `{s}`")),
+        };
+        Ok(order)
+    }
+}
+
+impl fmt::Display for TransactionOrder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            TransactionOrder::Fifo => f.write_str("fifo"),
+            TransactionOrder::Fees => f.write_str("fees"),
+        }
+    }
+}

--- a/crates/core/src/node/in_memory.rs
+++ b/crates/core/src/node/in_memory.rs
@@ -1265,7 +1265,7 @@ impl InMemoryNode {
         // Create a temporary tx pool (i.e. state is not shared with the node mempool).
         let pool = TxPool::new(
             self.impersonation.clone(),
-            self.read_inner()?.config.transactions_order,
+            self.read_inner()?.config.transaction_order,
         );
         pool.add_txs(txs);
 

--- a/crates/core/src/node/in_memory.rs
+++ b/crates/core/src/node/in_memory.rs
@@ -1262,10 +1262,9 @@ impl<S: ForkSource + std::fmt::Debug + Clone> InMemoryNode<S> {
     /// some txs have been applied while others have not).
     pub fn apply_txs(&self, txs: Vec<L2Tx>, max_transactions: usize) -> anyhow::Result<()> {
         tracing::debug!(count = txs.len(), "applying transactions");
-        let inner = self.read_inner()?;
 
         // Create a temporary tx pool (i.e. state is not shared with the node mempool).
-        let pool = TxPool::new(self.impersonation.clone(), inner.config.transactions_order);
+        let pool = TxPool::new(self.impersonation.clone(), self.read_inner()?.config.transactions_order);
         pool.add_txs(txs);
 
         // Lock time so that the produced blocks are guaranteed to be sequential in time.
@@ -1285,6 +1284,7 @@ impl<S: ForkSource + std::fmt::Debug + Clone> InMemoryNode<S> {
             let block_numer = self.seal_block(&mut time, tx_batch.txs, system_contracts)?;
 
             // Fetch the block that was just sealed
+            let inner = self.read_inner()?;
             let block = inner
                 .get_block(block_numer)
                 .expect("freshly sealed block could not be found in storage");

--- a/crates/core/src/node/in_memory.rs
+++ b/crates/core/src/node/in_memory.rs
@@ -1108,7 +1108,7 @@ fn contract_address_from_tx_result(execution_result: &VmExecutionResultAndLogs) 
 impl Default for InMemoryNode {
     fn default() -> Self {
         let impersonation = ImpersonationManager::default();
-        let pool = TxPool::new(impersonation.clone(), TransactionOrder::Fees);
+        let pool = TxPool::new(impersonation.clone(), TransactionOrder::Fifo);
         let tx_listener = pool.add_tx_listener();
         InMemoryNode::new(
             None,
@@ -1161,7 +1161,7 @@ impl InMemoryNode {
     // TODO: Refactor InMemoryNode with a builder pattern
     pub fn default_fork(fork: Option<ForkDetails>) -> Self {
         let impersonation = ImpersonationManager::default();
-        let pool = TxPool::new(impersonation.clone(), TransactionOrder::Fees);
+        let pool = TxPool::new(impersonation.clone(), TransactionOrder::Fifo);
         let tx_listener = pool.add_tx_listener();
         Self::new(
             fork,
@@ -2160,7 +2160,7 @@ mod tests {
             raw_storage: external_storage.inner.read().unwrap().raw_storage.clone(),
         };
         let impersonation = ImpersonationManager::default();
-        let pool = TxPool::new(impersonation.clone(), TransactionOrder::Fees);
+        let pool = TxPool::new(impersonation.clone(), TransactionOrder::Fifo);
         let sealer = BlockSealer::new(BlockSealerMode::immediate(1000, pool.add_tx_listener()));
         let node = InMemoryNode::new(
             Some(ForkDetails {
@@ -2200,7 +2200,7 @@ mod tests {
     #[tokio::test]
     async fn test_transact_returns_data_in_built_in_without_security_mode() {
         let impersonation = ImpersonationManager::default();
-        let pool = TxPool::new(impersonation.clone(), TransactionOrder::Fees);
+        let pool = TxPool::new(impersonation.clone(), TransactionOrder::Fifo);
         let sealer = BlockSealer::new(BlockSealerMode::immediate(1000, pool.add_tx_listener()));
         let node = InMemoryNode::new(
             None,

--- a/crates/core/src/node/in_memory.rs
+++ b/crates/core/src/node/in_memory.rs
@@ -1263,7 +1263,10 @@ impl InMemoryNode {
         tracing::debug!(count = txs.len(), "applying transactions");
 
         // Create a temporary tx pool (i.e. state is not shared with the node mempool).
-        let pool = TxPool::new(self.impersonation.clone(), self.read_inner()?.config.transactions_order);
+        let pool = TxPool::new(
+            self.impersonation.clone(),
+            self.read_inner()?.config.transactions_order,
+        );
         pool.add_txs(txs);
 
         // Lock time so that the produced blocks are guaranteed to be sequential in time.

--- a/crates/core/src/node/in_memory_ext.rs
+++ b/crates/core/src/node/in_memory_ext.rs
@@ -628,7 +628,7 @@ mod tests {
             rich_accounts: Default::default(),
             previous_states: Default::default(),
         };
-        let pool = TxPool::new(impersonation.clone(), TransactionOrder::Fees);
+        let pool = TxPool::new(impersonation.clone(), TransactionOrder::Fifo);
         let sealer = BlockSealer::new(BlockSealerMode::immediate(1000, pool.add_tx_listener()));
 
         let node = InMemoryNode {

--- a/crates/core/src/node/in_memory_ext.rs
+++ b/crates/core/src/node/in_memory_ext.rs
@@ -502,6 +502,7 @@ mod tests {
     use crate::node::time::{ReadTime, TimestampManager};
     use crate::node::{BlockSealer, ImpersonationManager, InMemoryNodeInner, Snapshot, TxPool};
     use crate::{http_fork_source::HttpForkSource, node::InMemoryNode};
+    use anvil_zksync_config::types::TransactionOrder;
     use std::str::FromStr;
     use std::sync::{Arc, RwLock};
     use zksync_multivm::interface::storage::ReadStorage;
@@ -629,7 +630,7 @@ mod tests {
             rich_accounts: Default::default(),
             previous_states: Default::default(),
         };
-        let pool = TxPool::new(impersonation.clone());
+        let pool = TxPool::new(impersonation.clone(), TransactionOrder::Fees);
         let sealer = BlockSealer::new(BlockSealerMode::immediate(1000, pool.add_tx_listener()));
 
         let node = InMemoryNode::<HttpForkSource> {

--- a/crates/core/src/node/in_memory_ext.rs
+++ b/crates/core/src/node/in_memory_ext.rs
@@ -441,7 +441,8 @@ impl InMemoryNode {
     }
 
     pub fn remove_pool_transactions(&self, address: Address) -> Result<()> {
-        self.pool.drop_transactions_by_sender(address);
+        self.pool
+            .drop_transactions(|tx| tx.transaction.common_data.initiator_address == address);
         Ok(())
     }
 

--- a/crates/core/src/node/pool.rs
+++ b/crates/core/src/node/pool.rs
@@ -251,7 +251,7 @@ mod tests {
     #[test]
     fn take_from_empty() {
         let impersonation = ImpersonationManager::default();
-        let pool = TxPool::new(impersonation, TransactionOrder::Fees);
+        let pool = TxPool::new(impersonation, TransactionOrder::Fifo);
         assert_eq!(pool.take_uniform(1), None);
     }
 
@@ -259,7 +259,7 @@ mod tests {
     #[test_case(true  ; "is impersonated")]
     fn take_zero(imp: bool) {
         let impersonation = ImpersonationManager::default();
-        let pool = TxPool::new(impersonation, TransactionOrder::Fees);
+        let pool = TxPool::new(impersonation, TransactionOrder::Fifo);
 
         pool.populate_impersonate([imp]);
         assert_eq!(pool.take_uniform(0), None);
@@ -269,7 +269,7 @@ mod tests {
     #[test_case(true  ; "is impersonated")]
     fn take_exactly_one(imp: bool) {
         let impersonation = ImpersonationManager::default();
-        let pool = TxPool::new(impersonation, TransactionOrder::Fees);
+        let pool = TxPool::new(impersonation, TransactionOrder::Fifo);
 
         let [tx0, ..] = pool.populate_impersonate([imp, false]);
         assert_eq!(
@@ -285,7 +285,7 @@ mod tests {
     #[test_case(true  ; "is impersonated")]
     fn take_exactly_two(imp: bool) {
         let impersonation = ImpersonationManager::default();
-        let pool = TxPool::new(impersonation, TransactionOrder::Fees);
+        let pool = TxPool::new(impersonation, TransactionOrder::Fifo);
 
         let [tx0, tx1, ..] = pool.populate_impersonate([imp, imp, false]);
         assert_eq!(
@@ -301,7 +301,7 @@ mod tests {
     #[test_case(true  ; "is impersonated")]
     fn take_one_eligible(imp: bool) {
         let impersonation = ImpersonationManager::default();
-        let pool = TxPool::new(impersonation, TransactionOrder::Fees);
+        let pool = TxPool::new(impersonation, TransactionOrder::Fifo);
 
         let [tx0, ..] = pool.populate_impersonate([imp, !imp, !imp, !imp]);
         assert_eq!(
@@ -319,7 +319,7 @@ mod tests {
     #[test_case(true  ; "is impersonated")]
     fn take_two_when_third_is_not_uniform(imp: bool) {
         let impersonation = ImpersonationManager::default();
-        let pool = TxPool::new(impersonation, TransactionOrder::Fees);
+        let pool = TxPool::new(impersonation, TransactionOrder::Fifo);
 
         let [tx0, tx1, ..] = pool.populate_impersonate([imp, imp, !imp]);
         assert_eq!(
@@ -337,7 +337,7 @@ mod tests {
     #[test_case(true  ; "is impersonated")]
     fn take_interrupted_by_non_uniformness(imp: bool) {
         let impersonation = ImpersonationManager::default();
-        let pool = TxPool::new(impersonation, TransactionOrder::Fees);
+        let pool = TxPool::new(impersonation, TransactionOrder::Fifo);
 
         let [tx0, tx1, ..] = pool.populate_impersonate([imp, imp, !imp, imp]);
         assert_eq!(
@@ -353,7 +353,7 @@ mod tests {
     #[test_case(true  ; "is impersonated")]
     fn take_multiple(imp: bool) {
         let impersonation = ImpersonationManager::default();
-        let pool = TxPool::new(impersonation, TransactionOrder::Fees);
+        let pool = TxPool::new(impersonation, TransactionOrder::Fifo);
 
         let [tx0, tx1, tx2, tx3] = pool.populate_impersonate([imp, !imp, !imp, imp]);
         assert_eq!(
@@ -383,7 +383,7 @@ mod tests {
     #[test_case(true  ; "is impersonated")]
     fn pool_clones_share_state(imp: bool) {
         let impersonation = ImpersonationManager::default();
-        let pool = TxPool::new(impersonation, TransactionOrder::Fees);
+        let pool = TxPool::new(impersonation, TransactionOrder::Fifo);
 
         let txs = {
             let pool_clone = pool.clone();
@@ -402,7 +402,7 @@ mod tests {
     #[test_case(true  ; "is impersonated")]
     fn take_multiple_from_clones(imp: bool) {
         let impersonation = ImpersonationManager::default();
-        let pool = TxPool::new(impersonation, TransactionOrder::Fees);
+        let pool = TxPool::new(impersonation, TransactionOrder::Fifo);
 
         let [tx0, tx1, tx2, tx3] = {
             let pool_clone = pool.clone();
@@ -439,7 +439,7 @@ mod tests {
     #[test_case(true  ; "is impersonated")]
     fn take_respects_impersonation_change(imp: bool) {
         let impersonation = ImpersonationManager::default();
-        let pool = TxPool::new(impersonation, TransactionOrder::Fees);
+        let pool = TxPool::new(impersonation, TransactionOrder::Fifo);
 
         let [tx0, tx1, tx2, tx3] = pool.populate_impersonate([imp, imp, !imp, imp]);
         assert_eq!(
@@ -471,7 +471,7 @@ mod tests {
     #[tokio::test]
     async fn take_uses_consistent_impersonation() {
         let impersonation = ImpersonationManager::default();
-        let pool = TxPool::new(impersonation.clone(), TransactionOrder::Fees);
+        let pool = TxPool::new(impersonation.clone(), TransactionOrder::Fifo);
 
         for _ in 0..4096 {
             let tx = testing::TransactionBuilder::new().build();

--- a/crates/core/src/node/sealer.rs
+++ b/crates/core/src/node/sealer.rs
@@ -154,6 +154,7 @@ mod tests {
     use crate::node::pool::TxBatch;
     use crate::node::sealer::BlockSealerMode;
     use crate::node::{BlockSealer, ImpersonationManager, TxPool};
+    use anvil_zksync_config::types::TransactionOrder;
     use std::ptr;
     use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
     use std::time::Duration;
@@ -175,7 +176,7 @@ mod tests {
 
     #[test]
     fn immediate_empty() {
-        let pool = TxPool::new(ImpersonationManager::default());
+        let pool = TxPool::new(ImpersonationManager::default(), TransactionOrder::Fees);
         let mut block_sealer =
             BlockSealer::new(BlockSealerMode::immediate(1000, pool.add_tx_listener()));
         let waker = &WAKER_NOOP;
@@ -186,7 +187,7 @@ mod tests {
 
     #[test]
     fn immediate_one_tx() {
-        let pool = TxPool::new(ImpersonationManager::default());
+        let pool = TxPool::new(ImpersonationManager::default(), TransactionOrder::Fees);
         let mut block_sealer =
             BlockSealer::new(BlockSealerMode::immediate(1000, pool.add_tx_listener()));
         let waker = &WAKER_NOOP;
@@ -206,7 +207,7 @@ mod tests {
 
     #[test]
     fn immediate_several_txs() {
-        let pool = TxPool::new(ImpersonationManager::default());
+        let pool = TxPool::new(ImpersonationManager::default(), TransactionOrder::Fees);
         let mut block_sealer =
             BlockSealer::new(BlockSealerMode::immediate(1000, pool.add_tx_listener()));
         let waker = &WAKER_NOOP;
@@ -226,7 +227,7 @@ mod tests {
 
     #[test]
     fn immediate_respect_max_txs() {
-        let pool = TxPool::new(ImpersonationManager::default());
+        let pool = TxPool::new(ImpersonationManager::default(), TransactionOrder::Fees);
         let mut block_sealer =
             BlockSealer::new(BlockSealerMode::immediate(3, pool.add_tx_listener()));
         let waker = &WAKER_NOOP;
@@ -247,7 +248,7 @@ mod tests {
 
     #[test]
     fn immediate_gradual_txs() {
-        let pool = TxPool::new(ImpersonationManager::default());
+        let pool = TxPool::new(ImpersonationManager::default(), TransactionOrder::Fees);
         let mut block_sealer =
             BlockSealer::new(BlockSealerMode::immediate(1000, pool.add_tx_listener()));
         let waker = &WAKER_NOOP;
@@ -285,7 +286,7 @@ mod tests {
 
     #[tokio::test]
     async fn fixed_time_very_long() {
-        let pool = TxPool::new(ImpersonationManager::default());
+        let pool = TxPool::new(ImpersonationManager::default(), TransactionOrder::Fees);
         let mut block_sealer = BlockSealer::new(BlockSealerMode::fixed_time(
             1000,
             Duration::from_secs(10000),
@@ -298,7 +299,7 @@ mod tests {
 
     #[tokio::test]
     async fn fixed_time_seal_empty() {
-        let pool = TxPool::new(ImpersonationManager::default());
+        let pool = TxPool::new(ImpersonationManager::default(), TransactionOrder::Fees);
         let mut block_sealer = BlockSealer::new(BlockSealerMode::fixed_time(
             1000,
             Duration::from_millis(100),
@@ -335,7 +336,7 @@ mod tests {
 
     #[tokio::test]
     async fn fixed_time_seal_with_txs() {
-        let pool = TxPool::new(ImpersonationManager::default());
+        let pool = TxPool::new(ImpersonationManager::default(), TransactionOrder::Fees);
         let mut block_sealer = BlockSealer::new(BlockSealerMode::fixed_time(
             1000,
             Duration::from_millis(100),
@@ -359,7 +360,7 @@ mod tests {
 
     #[tokio::test]
     async fn fixed_time_respect_max_txs() {
-        let pool = TxPool::new(ImpersonationManager::default());
+        let pool = TxPool::new(ImpersonationManager::default(), TransactionOrder::Fees);
         let mut block_sealer =
             BlockSealer::new(BlockSealerMode::fixed_time(3, Duration::from_millis(100)));
         let waker = &WAKER_NOOP;

--- a/crates/core/src/node/sealer.rs
+++ b/crates/core/src/node/sealer.rs
@@ -176,7 +176,7 @@ mod tests {
 
     #[test]
     fn immediate_empty() {
-        let pool = TxPool::new(ImpersonationManager::default(), TransactionOrder::Fees);
+        let pool = TxPool::new(ImpersonationManager::default(), TransactionOrder::Fifo);
         let mut block_sealer =
             BlockSealer::new(BlockSealerMode::immediate(1000, pool.add_tx_listener()));
         let waker = &WAKER_NOOP;
@@ -187,7 +187,7 @@ mod tests {
 
     #[test]
     fn immediate_one_tx() {
-        let pool = TxPool::new(ImpersonationManager::default(), TransactionOrder::Fees);
+        let pool = TxPool::new(ImpersonationManager::default(), TransactionOrder::Fifo);
         let mut block_sealer =
             BlockSealer::new(BlockSealerMode::immediate(1000, pool.add_tx_listener()));
         let waker = &WAKER_NOOP;
@@ -207,7 +207,7 @@ mod tests {
 
     #[test]
     fn immediate_several_txs() {
-        let pool = TxPool::new(ImpersonationManager::default(), TransactionOrder::Fees);
+        let pool = TxPool::new(ImpersonationManager::default(), TransactionOrder::Fifo);
         let mut block_sealer =
             BlockSealer::new(BlockSealerMode::immediate(1000, pool.add_tx_listener()));
         let waker = &WAKER_NOOP;
@@ -227,7 +227,7 @@ mod tests {
 
     #[test]
     fn immediate_respect_max_txs() {
-        let pool = TxPool::new(ImpersonationManager::default(), TransactionOrder::Fees);
+        let pool = TxPool::new(ImpersonationManager::default(), TransactionOrder::Fifo);
         let mut block_sealer =
             BlockSealer::new(BlockSealerMode::immediate(3, pool.add_tx_listener()));
         let waker = &WAKER_NOOP;
@@ -248,7 +248,7 @@ mod tests {
 
     #[test]
     fn immediate_gradual_txs() {
-        let pool = TxPool::new(ImpersonationManager::default(), TransactionOrder::Fees);
+        let pool = TxPool::new(ImpersonationManager::default(), TransactionOrder::Fifo);
         let mut block_sealer =
             BlockSealer::new(BlockSealerMode::immediate(1000, pool.add_tx_listener()));
         let waker = &WAKER_NOOP;
@@ -286,7 +286,7 @@ mod tests {
 
     #[tokio::test]
     async fn fixed_time_very_long() {
-        let pool = TxPool::new(ImpersonationManager::default(), TransactionOrder::Fees);
+        let pool = TxPool::new(ImpersonationManager::default(), TransactionOrder::Fifo);
         let mut block_sealer = BlockSealer::new(BlockSealerMode::fixed_time(
             1000,
             Duration::from_secs(10000),
@@ -299,7 +299,7 @@ mod tests {
 
     #[tokio::test]
     async fn fixed_time_seal_empty() {
-        let pool = TxPool::new(ImpersonationManager::default(), TransactionOrder::Fees);
+        let pool = TxPool::new(ImpersonationManager::default(), TransactionOrder::Fifo);
         let mut block_sealer = BlockSealer::new(BlockSealerMode::fixed_time(
             1000,
             Duration::from_millis(100),
@@ -336,7 +336,7 @@ mod tests {
 
     #[tokio::test]
     async fn fixed_time_seal_with_txs() {
-        let pool = TxPool::new(ImpersonationManager::default(), TransactionOrder::Fees);
+        let pool = TxPool::new(ImpersonationManager::default(), TransactionOrder::Fifo);
         let mut block_sealer = BlockSealer::new(BlockSealerMode::fixed_time(
             1000,
             Duration::from_millis(100),
@@ -360,7 +360,7 @@ mod tests {
 
     #[tokio::test]
     async fn fixed_time_respect_max_txs() {
-        let pool = TxPool::new(ImpersonationManager::default(), TransactionOrder::Fees);
+        let pool = TxPool::new(ImpersonationManager::default(), TransactionOrder::Fifo);
         let mut block_sealer =
             BlockSealer::new(BlockSealerMode::fixed_time(3, Duration::from_millis(100)));
         let waker = &WAKER_NOOP;

--- a/e2e-tests-rust/src/provider/testing.rs
+++ b/e2e-tests-rust/src/provider/testing.rs
@@ -469,6 +469,12 @@ where
         self
     }
 
+    /// Builder-pattern method for setting max fee per gas.
+    pub fn with_max_fee_per_gas(mut self, max_fee_per_gas: u128) -> Self {
+        self.inner = self.inner.with_max_fee_per_gas(max_fee_per_gas);
+        self
+    }
+
     /// Submits transaction to the node.
     ///
     /// This does not wait for the transaction to be confirmed, but returns a [`PendingTransactionFinalizable`]

--- a/e2e-tests-rust/tests/lib.rs
+++ b/e2e-tests-rust/tests/lib.rs
@@ -5,6 +5,7 @@ use anvil_zksync_e2e_tests::{
     init_testing_provider, init_testing_provider_with_http_headers, AnvilZKsyncApi, ReceiptExt, ZksyncWalletProviderExt, DEFAULT_TX_VALUE,
 };
 use alloy::{
+    network::primitives::BlockTransactionsKind,
     primitives::U256,
     signers::local::PrivateKeySigner,
 };
@@ -396,5 +397,41 @@ async fn cli_allow_origin() -> anyhow::Result<()> {
     let error_resp = provider_with_not_allowed_origin.get_chain_id().await.unwrap_err();
     assert_eq!(error_resp.to_string().contains("Origin of the request is not whitelisted"), true);
 
+    Ok(())
+}
+
+#[tokio::test]
+async fn pool_txs_order_fifo() -> anyhow::Result<()> {
+    let provider_fifo = init_testing_provider(|node| node.no_mine()).await?;
+
+    let pending_tx0 = provider_fifo.tx().with_rich_from(0).with_max_fee_per_gas(50_000_000).register().await?;
+    let pending_tx1 = provider_fifo.tx().with_rich_from(1).with_max_fee_per_gas(100_000_000).register().await?;
+    let pending_tx2 = provider_fifo.tx().with_rich_from(2).with_max_fee_per_gas(150_000_000).register().await?;
+
+    provider_fifo.anvil_mine(Some(U256::from(1)), None).await?;
+
+    let block = provider_fifo.get_block(1.into(), BlockTransactionsKind::Hashes).await?.unwrap();
+    let tx_hashes = block.transactions.as_hashes().unwrap();
+    assert_eq!(&tx_hashes[0], pending_tx0.tx_hash());
+    assert_eq!(&tx_hashes[1], pending_tx1.tx_hash());
+    assert_eq!(&tx_hashes[2], pending_tx2.tx_hash());
+    Ok(())
+}
+
+#[tokio::test]
+async fn pool_txs_order_fees() -> anyhow::Result<()> {
+    let provider_fees = init_testing_provider(|node| node.no_mine().arg("--order=fees")).await?;
+
+    let pending_tx0 = provider_fees.tx().with_rich_from(0).with_max_fee_per_gas(50_000_000).register().await?;
+    let pending_tx1 = provider_fees.tx().with_rich_from(1).with_max_fee_per_gas(100_000_000).register().await?;
+    let pending_tx2 = provider_fees.tx().with_rich_from(2).with_max_fee_per_gas(150_000_000).register().await?;
+
+    provider_fees.anvil_mine(Some(U256::from(1)), None).await?;
+
+    let block = provider_fees.get_block(1.into(), BlockTransactionsKind::Hashes).await?.unwrap();
+    let tx_hashes = block.transactions.as_hashes().unwrap();
+    assert_eq!(&tx_hashes[0], pending_tx2.tx_hash());
+    assert_eq!(&tx_hashes[1], pending_tx1.tx_hash());
+    assert_eq!(&tx_hashes[2], pending_tx0.tx_hash());
     Ok(())
 }


### PR DESCRIPTION
# What :computer: 
- Added CLI param `--order` for transactions order in mempool.
- Added `fees` transactions order option, sorts transactions by `max_fee_per_gas`.
- FIFO is still the default option to reflect mainnet.

# Why :hand:
Feature parity with anvil.
