### PR TITLE
refactor: remove `S` generic from `InMemoryNode` and `ForkStorage`

### DIFF
--- a/crates/cli/src/bytecode_override.rs
+++ b/crates/cli/src/bytecode_override.rs
@@ -1,6 +1,5 @@
 use std::fs;
 
-use anvil_zksync_core::fork::ForkSource;
 use anvil_zksync_core::node::InMemoryNode;
 use eyre::Context;
 use hex::FromHex;
@@ -20,10 +19,7 @@ struct Bytecode {
 
 // Loads a list of bytecodes and addresses from the directory and then inserts them directly
 // into the Node's storage.
-pub fn override_bytecodes<T: Clone + ForkSource + std::fmt::Debug>(
-    node: &InMemoryNode<T>,
-    bytecodes_dir: String,
-) -> eyre::Result<()> {
+pub fn override_bytecodes(node: &InMemoryNode, bytecodes_dir: String) -> eyre::Result<()> {
     for entry in fs::read_dir(bytecodes_dir)? {
         let entry = entry?;
         let path = entry.path();

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -8,8 +8,7 @@ use anvil_zksync_config::constants::{
 };
 use anvil_zksync_config::types::SystemContractsOptions;
 use anvil_zksync_config::ForkPrintInfo;
-use anvil_zksync_core::fork::{ForkDetails, ForkSource};
-use anvil_zksync_core::http_fork_source::HttpForkSource;
+use anvil_zksync_core::fork::ForkDetails;
 use anvil_zksync_core::namespaces::{
     AnvilNamespaceT, ConfigurationApiNamespaceT, DebugNamespaceT, EthNamespaceT,
     EthTestNodeNamespaceT, EvmNamespaceT, HardhatNamespaceT, NetNamespaceT, Web3NamespaceT,
@@ -43,12 +42,10 @@ mod logging_middleware;
 mod utils;
 
 #[allow(clippy::too_many_arguments)]
-async fn build_json_http<
-    S: std::marker::Sync + std::marker::Send + 'static + ForkSource + std::fmt::Debug + Clone,
->(
+async fn build_json_http(
     addr: SocketAddr,
     log_level_filter: LevelFilter,
-    node: InMemoryNode<S>,
+    node: InMemoryNode,
     enable_health_api: bool,
 ) -> tokio::task::JoinHandle<()> {
     let (sender, recv) = oneshot::channel::<()>();
@@ -280,7 +277,7 @@ async fn main() -> anyhow::Result<()> {
     };
     let block_sealer = BlockSealer::new(sealing_mode);
 
-    let node: InMemoryNode<HttpForkSource> = InMemoryNode::new(
+    let node: InMemoryNode = InMemoryNode::new(
         fork_details,
         Some(observability),
         &config,

--- a/crates/core/src/node/anvil.rs
+++ b/crates/core/src/node/anvil.rs
@@ -6,15 +6,12 @@ use zksync_web3_decl::error::Web3Error;
 use crate::namespaces::DetailedTransaction;
 use crate::utils::Numeric;
 use crate::{
-    fork::ForkSource,
     namespaces::{AnvilNamespaceT, ResetRequest, RpcResult},
     node::InMemoryNode,
     utils::{into_jsrpc_error, into_jsrpc_error_message, IntoBoxedFuture},
 };
 
-impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> AnvilNamespaceT
-    for InMemoryNode<S>
-{
+impl AnvilNamespaceT for InMemoryNode {
     fn dump_state(&self, preserve_historical_states: Option<bool>) -> RpcResult<Bytes> {
         self.dump_state(preserve_historical_states.unwrap_or(false))
             .map_err(|err| {
@@ -231,7 +228,7 @@ impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> AnvilNames
     }
 
     fn stop_impersonating_account(&self, address: Address) -> RpcResult<()> {
-        InMemoryNode::<S>::stop_impersonating_account(self, address)
+        InMemoryNode::stop_impersonating_account(self, address)
             .map(|_| ())
             .map_err(|err| {
                 tracing::error!("failed stopping to impersonate account: {:?}", err);

--- a/crates/core/src/node/block_producer.rs
+++ b/crates/core/src/node/block_producer.rs
@@ -1,24 +1,22 @@
-use crate::fork::ForkSource;
 use crate::node::pool::{TxBatch, TxPool};
 use crate::node::sealer::BlockSealer;
 use crate::node::InMemoryNode;
 use crate::system_contracts::SystemContracts;
-use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use zksync_multivm::interface::TxExecutionMode;
 
-pub struct BlockProducer<S: Clone> {
-    node: InMemoryNode<S>,
+pub struct BlockProducer {
+    node: InMemoryNode,
     pool: TxPool,
     block_sealer: BlockSealer,
     system_contracts: SystemContracts,
 }
 
-impl<S: Clone> BlockProducer<S> {
+impl BlockProducer {
     pub fn new(
-        node: InMemoryNode<S>,
+        node: InMemoryNode,
         pool: TxPool,
         block_sealer: BlockSealer,
         system_contracts: SystemContracts,
@@ -32,7 +30,7 @@ impl<S: Clone> BlockProducer<S> {
     }
 }
 
-impl<S: ForkSource + Clone + fmt::Debug> Future for BlockProducer<S> {
+impl Future for BlockProducer {
     type Output = ();
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {

--- a/crates/core/src/node/config_api.rs
+++ b/crates/core/src/node/config_api.rs
@@ -1,6 +1,5 @@
 use crate::node::time::ReadTime;
 use crate::{
-    fork::ForkSource,
     namespaces::{ConfigurationApiNamespaceT, Result},
     node::InMemoryNode,
     utils::into_jsrpc_error,
@@ -10,9 +9,7 @@ use anvil_zksync_config::types::{
 };
 use zksync_web3_decl::error::Web3Error;
 
-impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> ConfigurationApiNamespaceT
-    for InMemoryNode<S>
-{
+impl ConfigurationApiNamespaceT for InMemoryNode {
     fn config_get_show_calls(&self) -> Result<String> {
         self.get_inner()
             .read()

--- a/crates/core/src/node/debug.rs
+++ b/crates/core/src/node/debug.rs
@@ -17,15 +17,12 @@ use zksync_web3_decl::error::Web3Error;
 
 use crate::{
     deps::storage_view::StorageView,
-    fork::ForkSource,
     namespaces::{DebugNamespaceT, Result, RpcResult},
     node::{InMemoryNode, MAX_TX_SIZE},
     utils::{create_debug_output, into_jsrpc_error, to_real_block_number},
 };
 
-impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> DebugNamespaceT
-    for InMemoryNode<S>
-{
+impl DebugNamespaceT for InMemoryNode {
     fn trace_block_by_number(
         &self,
         block: BlockNumber,
@@ -247,12 +244,11 @@ mod tests {
     use super::*;
     use crate::{
         deps::system_contracts::bytecode_from_slice,
-        http_fork_source::HttpForkSource,
         node::{InMemoryNode, TransactionResult},
         testing::{self, LogBuilder},
     };
 
-    fn deploy_test_contracts(node: &InMemoryNode<HttpForkSource>) -> (Address, Address) {
+    fn deploy_test_contracts(node: &InMemoryNode) -> (Address, Address) {
         let private_key = K256PrivateKey::from_bytes(H256::repeat_byte(0xee)).unwrap();
         let from_account = private_key.address();
         node.set_rich_account(from_account, U256::from(DEFAULT_ACCOUNT_BALANCE));
@@ -291,7 +287,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_trace_deployed_contract() {
-        let node = InMemoryNode::<HttpForkSource>::default();
+        let node = InMemoryNode::default();
 
         let (primary_deployed_address, secondary_deployed_address) = deploy_test_contracts(&node);
         // trace a call to the primary contract
@@ -340,7 +336,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_trace_only_top() {
-        let node = InMemoryNode::<HttpForkSource>::default();
+        let node = InMemoryNode::default();
 
         let (primary_deployed_address, _) = deploy_test_contracts(&node);
 
@@ -377,7 +373,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_trace_reverts() {
-        let node = InMemoryNode::<HttpForkSource>::default();
+        let node = InMemoryNode::default();
 
         let (primary_deployed_address, _) = deploy_test_contracts(&node);
 
@@ -412,7 +408,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_trace_transaction() {
-        let node = InMemoryNode::<HttpForkSource>::default();
+        let node = InMemoryNode::default();
         let inner = node.get_inner();
         {
             let mut writer = inner.write().unwrap();
@@ -440,7 +436,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_trace_transaction_only_top() {
-        let node = InMemoryNode::<HttpForkSource>::default();
+        let node = InMemoryNode::default();
         let inner = node.get_inner();
         {
             let mut writer = inner.write().unwrap();
@@ -476,7 +472,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_trace_transaction_not_found() {
-        let node = InMemoryNode::<HttpForkSource>::default();
+        let node = InMemoryNode::default();
         let result = node
             .trace_transaction(H256::repeat_byte(0x1), None)
             .await
@@ -486,7 +482,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_trace_block_by_hash_empty() {
-        let node = InMemoryNode::<HttpForkSource>::default();
+        let node = InMemoryNode::default();
         let inner = node.get_inner();
         {
             let mut writer = inner.write().unwrap();
@@ -502,7 +498,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_trace_block_by_hash() {
-        let node = InMemoryNode::<HttpForkSource>::default();
+        let node = InMemoryNode::default();
         let inner = node.get_inner();
         {
             let mut writer = inner.write().unwrap();
@@ -530,7 +526,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_trace_block_by_number() {
-        let node = InMemoryNode::<HttpForkSource>::default();
+        let node = InMemoryNode::default();
         let inner = node.get_inner();
         {
             let mut writer = inner.write().unwrap();

--- a/crates/core/src/node/evm.rs
+++ b/crates/core/src/node/evm.rs
@@ -3,15 +3,12 @@ use zksync_web3_decl::error::Web3Error;
 
 use crate::utils::Numeric;
 use crate::{
-    fork::ForkSource,
     namespaces::{EvmNamespaceT, RpcResult},
     node::InMemoryNode,
     utils::{into_jsrpc_error, IntoBoxedFuture},
 };
 
-impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> EvmNamespaceT
-    for InMemoryNode<S>
-{
+impl EvmNamespaceT for InMemoryNode {
     fn increase_time(&self, time_delta_seconds: Numeric) -> RpcResult<u64> {
         self.increase_time(time_delta_seconds)
             .map_err(|err| {

--- a/crates/core/src/node/hardhat.rs
+++ b/crates/core/src/node/hardhat.rs
@@ -2,15 +2,12 @@ use zksync_types::{Address, U256, U64};
 use zksync_web3_decl::error::Web3Error;
 
 use crate::{
-    fork::ForkSource,
     namespaces::{HardhatNamespaceT, ResetRequest, RpcResult},
     node::InMemoryNode,
     utils::{into_jsrpc_error, into_jsrpc_error_message, IntoBoxedFuture},
 };
 
-impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> HardhatNamespaceT
-    for InMemoryNode<S>
-{
+impl HardhatNamespaceT for InMemoryNode {
     fn set_balance(&self, address: Address, balance: U256) -> RpcResult<bool> {
         self.set_balance(address, balance)
             .map_err(|err| {
@@ -66,7 +63,7 @@ impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> HardhatNam
     }
 
     fn stop_impersonating_account(&self, address: Address) -> RpcResult<bool> {
-        InMemoryNode::<S>::stop_impersonating_account(self, address)
+        InMemoryNode::stop_impersonating_account(self, address)
             .map_err(|err| {
                 tracing::error!("failed stopping to impersonate account: {:?}", err);
                 into_jsrpc_error(Web3Error::InternalError(err))

--- a/crates/core/src/node/net.rs
+++ b/crates/core/src/node/net.rs
@@ -1,14 +1,11 @@
 use crate::{
-    fork::ForkSource,
     namespaces::{NetNamespaceT, Result},
     node::InMemoryNode,
 };
 use anvil_zksync_config::constants::TEST_NODE_NETWORK_ID;
 use zksync_types::U256;
 
-impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> NetNamespaceT
-    for InMemoryNode<S>
-{
+impl NetNamespaceT for InMemoryNode {
     fn net_version(&self) -> Result<String> {
         let chain_id = self
             .get_inner()

--- a/crates/core/src/node/web3.rs
+++ b/crates/core/src/node/web3.rs
@@ -1,12 +1,9 @@
 use crate::{
-    fork::ForkSource,
     namespaces::{Result, Web3NamespaceT},
     node::InMemoryNode,
 };
 
-impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> Web3NamespaceT
-    for InMemoryNode<S>
-{
+impl Web3NamespaceT for InMemoryNode {
     fn web3_client_version(&self) -> Result<String> {
         Ok("zkSync/v2.0".to_string())
     }

--- a/crates/core/src/node/zks.rs
+++ b/crates/core/src/node/zks.rs
@@ -17,7 +17,6 @@ use zksync_utils::h256_to_u256;
 use zksync_web3_decl::error::Web3Error;
 
 use crate::{
-    fork::ForkSource,
     namespaces::{RpcResult, ZksNamespaceT},
     node::{InMemoryNode, TransactionResult},
     utils::{
@@ -26,9 +25,7 @@ use crate::{
     },
 };
 
-impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> ZksNamespaceT
-    for InMemoryNode<S>
-{
+impl ZksNamespaceT for InMemoryNode {
     /// Estimates the gas fee data required for a given call request.
     ///
     /// # Arguments
@@ -588,7 +585,6 @@ mod tests {
     use super::*;
     use crate::{
         fork::ForkDetails,
-        http_fork_source::HttpForkSource,
         node::InMemoryNode,
         testing,
         testing::{ForkBlockConfig, MockServer},
@@ -596,7 +592,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_estimate_fee() {
-        let node = InMemoryNode::<HttpForkSource>::default();
+        let node = InMemoryNode::default();
 
         let mock_request = CallRequest {
             from: Some(
@@ -633,7 +629,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_token_price_given_eth_should_return_price() {
         // Arrange
-        let node = InMemoryNode::<HttpForkSource>::default();
+        let node = InMemoryNode::default();
 
         let mock_address = Address::from_str("0x0000000000000000000000000000000000000000")
             .expect("Failed to parse address");
@@ -648,7 +644,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_token_price_given_capitalized_link_address_should_return_price() {
         // Arrange
-        let node = InMemoryNode::<HttpForkSource>::default();
+        let node = InMemoryNode::default();
 
         let mock_address = Address::from_str("0x40609141Db628BeEE3BfAB8034Fc2D8278D0Cc78")
             .expect("Failed to parse address");
@@ -663,7 +659,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_token_price_given_unknown_address_should_return_error() {
         // Arrange
-        let node = InMemoryNode::<HttpForkSource>::default();
+        let node = InMemoryNode::default();
 
         let mock_address = Address::from_str("0x0000000000000000000000000000000000000042")
             .expect("Failed to parse address");
@@ -678,7 +674,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_transaction_details_local() {
         // Arrange
-        let node = InMemoryNode::<HttpForkSource>::default();
+        let node = InMemoryNode::default();
         let inner = node.get_inner();
         {
             let mut writer = inner.write().unwrap();
@@ -741,7 +737,7 @@ mod tests {
             }),
         );
 
-        let node = InMemoryNode::<HttpForkSource>::default_fork(Some(
+        let node = InMemoryNode::default_fork(Some(
             ForkDetails::from_network(&mock_server.url(), None, &CacheConfig::None)
                 .await
                 .unwrap(),
@@ -760,7 +756,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_block_details_local() {
         // Arrange
-        let node = InMemoryNode::<HttpForkSource>::default();
+        let node = InMemoryNode::default();
         let inner = node.get_inner();
         {
             let mut writer = inner.write().unwrap();
@@ -827,7 +823,7 @@ mod tests {
               }),
         );
 
-        let node = InMemoryNode::<HttpForkSource>::default_fork(Some(
+        let node = InMemoryNode::default_fork(Some(
             ForkDetails::from_network(&mock_server.url(), None, &CacheConfig::None)
                 .await
                 .unwrap(),
@@ -848,7 +844,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_bridge_contracts_uses_default_values_if_local() {
         // Arrange
-        let node = InMemoryNode::<HttpForkSource>::default();
+        let node = InMemoryNode::default();
         let expected_bridge_addresses = BridgeAddresses {
             l1_shared_default_bridge: Default::default(),
             l2_shared_default_bridge: Default::default(),
@@ -905,7 +901,7 @@ mod tests {
             }),
         );
 
-        let node = InMemoryNode::<HttpForkSource>::default_fork(Some(
+        let node = InMemoryNode::default_fork(Some(
             ForkDetails::from_network(&mock_server.url(), None, &CacheConfig::None)
                 .await
                 .unwrap(),
@@ -923,7 +919,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_bytecode_by_hash_returns_local_value_if_available() {
         // Arrange
-        let node = InMemoryNode::<HttpForkSource>::default();
+        let node = InMemoryNode::default();
         let input_hash = H256::repeat_byte(0x1);
         let input_bytecode = vec![0x1];
         node.get_inner()
@@ -968,7 +964,7 @@ mod tests {
             }),
         );
 
-        let node = InMemoryNode::<HttpForkSource>::default_fork(Some(
+        let node = InMemoryNode::default_fork(Some(
             ForkDetails::from_network(&mock_server.url(), None, &CacheConfig::None)
                 .await
                 .unwrap(),
@@ -987,7 +983,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_raw_block_transactions_local() {
         // Arrange
-        let node = InMemoryNode::<HttpForkSource>::default();
+        let node = InMemoryNode::default();
         let inner = node.get_inner();
         {
             let mut writer = inner.write().unwrap();
@@ -1089,7 +1085,7 @@ mod tests {
               }),
         );
 
-        let node = InMemoryNode::<HttpForkSource>::default_fork(Some(
+        let node = InMemoryNode::default_fork(Some(
             ForkDetails::from_network(&mock_server.url(), None, &CacheConfig::None)
                 .await
                 .unwrap(),
@@ -1104,7 +1100,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_all_account_balances_empty() {
-        let node = InMemoryNode::<HttpForkSource>::default();
+        let node = InMemoryNode::default();
         let balances = node
             .get_all_account_balances(Address::zero())
             .await
@@ -1114,7 +1110,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_confirmed_tokens_eth() {
-        let node = InMemoryNode::<HttpForkSource>::default();
+        let node = InMemoryNode::default();
         let balances = node
             .get_confirmed_tokens(0, 100)
             .await
@@ -1125,7 +1121,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_l1_chain_id() {
-        let node = InMemoryNode::<HttpForkSource>::default();
+        let node = InMemoryNode::default();
         let chain_id = node.l1_chain_id().await.expect("get chain id").as_u32();
         assert_eq!(TEST_NODE_NETWORK_ID, chain_id);
     }
@@ -1268,7 +1264,7 @@ mod tests {
             }),
         );
 
-        let node = InMemoryNode::<HttpForkSource>::default_fork(Some(
+        let node = InMemoryNode::default_fork(Some(
             ForkDetails::from_network(&mock_server.url(), Some(1), &CacheConfig::None)
                 .await
                 .unwrap(),
@@ -1296,7 +1292,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_base_token_l1_address() {
-        let node = InMemoryNode::<HttpForkSource>::default();
+        let node = InMemoryNode::default();
         let token_address = node
             .get_base_token_l1_address()
             .await

--- a/crates/core/src/testing.rs
+++ b/crates/core/src/testing.rs
@@ -473,10 +473,7 @@ impl TransactionBuilder {
 }
 
 /// Applies a transaction with a given hash to the node and returns the block hash.
-pub fn apply_tx<T: ForkSource + std::fmt::Debug + Clone>(
-    node: &InMemoryNode<T>,
-    tx_hash: H256,
-) -> (H256, U64, L2Tx) {
+pub fn apply_tx(node: &InMemoryNode, tx_hash: H256) -> (H256, U64, L2Tx) {
     let next_miniblock = node
         .get_inner()
         .read()
@@ -497,8 +494,8 @@ pub fn apply_tx<T: ForkSource + std::fmt::Debug + Clone>(
 }
 
 /// Deploys a contract with the given bytecode.
-pub fn deploy_contract<T: ForkSource + std::fmt::Debug + Clone>(
-    node: &InMemoryNode<T>,
+pub fn deploy_contract(
+    node: &InMemoryNode,
     tx_hash: H256,
     private_key: &K256PrivateKey,
     bytecode: Vec<u8>,
@@ -888,7 +885,6 @@ mod test {
     use zksync_utils::h256_to_u256;
 
     use super::*;
-    use crate::http_fork_source::HttpForkSource;
 
     #[test]
     fn test_block_response_builder_set_hash() {
@@ -976,7 +972,7 @@ mod test {
 
     #[tokio::test]
     async fn test_apply_tx() {
-        let node = InMemoryNode::<HttpForkSource>::default();
+        let node = InMemoryNode::default();
         let (actual_block_hash, actual_block_number, _) = apply_tx(&node, H256::repeat_byte(0x01));
 
         assert_eq!(


### PR DESCRIPTION
# What :computer: 
Closes #493 

This generic hasn't been useful for quite some time (effectively does nothing as its functionality was moved to `fork_source: Box<dyn ForkSource + Send + Sync>` in `ForkDetails`). This is a good opportunity to simplify our code as this generic appears all over the place without being needed.

# Why :hand:
Dead code