### PR TITLE
fix: properly set transaction index

### DIFF
--- a/crates/core/src/node/eth.rs
+++ b/crates/core/src/node/eth.rs
@@ -567,7 +567,7 @@ impl EthNamespaceT for InMemoryNode {
 
             let maybe_result = {
                 // try retrieving transaction from memory, and if unavailable subsequently from the fork
-                reader.tx_results.get(&hash).and_then(|TransactionResult { info, .. }| {
+                reader.tx_results.get(&hash).and_then(|TransactionResult { info, receipt, .. }| {
                     let input_data = info.tx.common_data.input.clone().or(None)?;
                     let chain_id = info.tx.common_data.extract_chain_id().or(None)?;
                     Some(zksync_types::api::Transaction {
@@ -575,7 +575,7 @@ impl EthNamespaceT for InMemoryNode {
                         nonce: U256::from(info.tx.common_data.nonce.0),
                         block_hash: Some(hash),
                         block_number: Some(U64::from(info.miniblock_number)),
-                        transaction_index: Some(U64::from(0)),
+                        transaction_index: Some(receipt.transaction_index),
                         from: Some(info.tx.initiator_account()),
                         to: info.tx.recipient_account(),
                         value: info.tx.execute.value,

--- a/e2e-tests-rust/tests/lib.rs
+++ b/e2e-tests-rust/tests/lib.rs
@@ -398,3 +398,19 @@ async fn cli_allow_origin() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn transactions_have_index() -> anyhow::Result<()> {
+    let provider = init_testing_provider(|node| node.no_mine()).await?;
+    let tx1 = provider.tx().with_rich_from(0).register().await?;
+    let tx2 = provider.tx().with_rich_from(1).register().await?;
+
+    provider.anvil_mine(Some(U256::from(1)), None).await?;
+
+    let receipt1 = tx1.wait_until_finalized().await?;
+    let receipt2 = tx2.wait_until_finalized().await?;
+
+    assert_eq!(receipt1.transaction_index(), 0.into());
+    assert_eq!(receipt2.transaction_index(), 1.into());
+    Ok(())
+}


### PR DESCRIPTION
# What :computer: 
- Properly set transaction index.

# Why :hand:
- Since block can have many transactions using `0` as tx index is no longer valid.

Closes https://github.com/matter-labs/anvil-zksync/issues/498
