### PR TITLE
feat: Add binary attestation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,9 @@ jobs:
       VERSION: ${{ steps.extract_version.outputs.VERSION }}
 
   build:
+    permissions:
+      id-token: write
+      attestations: write
     name: build release
     strategy:
       matrix:
@@ -96,6 +99,11 @@ jobs:
         with:
           name: anvil-zksync-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.arch }}.tar.gz
           path: anvil-zksync-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.arch }}.tar.gz
+
+      - name: Binaries attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: target/release/anvil-zksync
 
   draft-release:
     name: draft release


### PR DESCRIPTION
# What :computer: 

Adds binary attestations for releases (for now, only for binaries).
See [action](https://github.com/actions/attest-build-provenance)

# Why :hand:

Allows to verify the validity of the binary. See [gh attestation verify](https://cli.github.com/manual/gh_attestation_verify)

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
