### PR TITLE
fix: Print correct port for spawned server

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -273,7 +273,9 @@ async fn main() -> anyhow::Result<()> {
     let mut server_handles = Vec::with_capacity(config.host.len());
     for host in &config.host {
         let addr = SocketAddr::new(*host, config.port);
-        server_handles.push(server_builder.clone().build(addr).await.run());
+        let server = server_builder.clone().build(addr).await;
+        config.port = server.local_addr().port();
+        server_handles.push(server.run());
     }
     let any_server_stopped =
         futures::future::select_all(server_handles.into_iter().map(|h| Box::pin(h.stopped())));


### PR DESCRIPTION
# What :computer: 

When we spawn the node with port = 0, it means that the system will allocate any free port for us.
However currently we will print that the node runs on port 0 (which is incorrect).
This PR fixes it.

# Evidence :camera:

![image](https://github.com/user-attachments/assets/af714d67-9173-424f-bfed-3de962b20ac7)

