### PR TITLE
chore: fix release attestation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Binaries attestation
         uses: actions/attest-build-provenance@v2
         with:
-          subject-path: target/release/anvil-zksync
+          subject-path: ./artifacts/anvil-zksync
 
   draft-release:
     name: draft release


### PR DESCRIPTION
# What :computer: 
Fixes the attestation path

# Why :hand:
Binary's path depends on the target triple and is moved in the release pipeline