### PR TITLE
fix: fixes install script for apple x86

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -86,6 +86,10 @@ function get_os_info() {
         "Darwin")
             os="apple-darwin"
             arch=$(arch)
+            if [[ "$arch" == "i386" ]]; then
+                # Rosetta reports as i386, but we treat it as x86_64
+                arch="x86_64"
+            fi
             ;;
         *)
             echo "ERROR: anvil-zksync only supports Linux and MacOS! Detected OS: $unamestr"
@@ -101,6 +105,8 @@ function get_os_info() {
             architecture="aarch64"
             ;;
         *)
+            echo "Operating system: $os"
+            echo "Architecture: $arch"
             echo "ERROR: Unsupported architecture detected!"
             exit 1
             ;;


### PR DESCRIPTION
# What :computer: 
* Fixes install script for apple as the arch is detected as `i386` 
* Fixes here as well: https://github.com/matter-labs/foundry-zksync/pull/820
* Closes #519 

# Why :hand:
* Properly makes use of x86 binary

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
