### PR TITLE
fix: fixes anvil-zksync failing on ubuntu-latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,11 @@ jobs:
 
       - name: Build anvil-zksync for ${{ matrix.arch }}
         run: |
-          make build-${{ matrix.arch }}
+          if [[ "${{ matrix.arch }}" == *"linux"* ]]; then
+            make build-static-${{ matrix.arch }}
+          else
+            make build-${{ matrix.arch }}
+          fi
 
       - name: Rename and move binary
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,9 +41,9 @@ jobs:
           ]
         include:
           - arch: x86_64-unknown-linux-gnu
-            platform: ubuntu-20.04
+            platform: ubuntu-latest
           - arch: aarch64-unknown-linux-gnu
-            platform: ubuntu-20.04
+            platform: ubuntu-latest
           - arch: x86_64-apple-darwin
             platform: macos-latest
           - arch: aarch64-apple-darwin

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,14 +1,14 @@
-# Cross.toml
-
 [target.x86_64-unknown-linux-gnu]
+image = "ubuntu:22.04"
 pre-build = [
     "export DEBIAN_FRONTEND=noninteractive",
     "export TZ=Etc/UTC",
     "dpkg --add-architecture $CROSS_DEB_ARCH",
-    "apt update -q && apt upgrade -yq && apt install --assume-yes --no-install-recommends libclang-10-dev clang-10 cmake build-essential pkg-config libssl-dev:$CROSS_DEB_ARCH libsasl2-dev llvm-dev gnutls-bin",
-    "apt install -y gcc-10 g++-10",
-    "update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 10",
-    "update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 10"
+    "apt update -q && apt upgrade -yq",
+    "apt install --assume-yes --no-install-recommends libclang-14-dev clang-14 cmake build-essential pkg-config libssl-dev:$CROSS_DEB_ARCH libsasl2-dev llvm-14-dev gnutls-bin",
+    "apt install -y gcc-11 g++-11",
+    "update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 11",
+    "update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 11"
 ]
 
 [target.aarch64-unknown-linux-gnu]

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,10 @@ run: all
 build-%:
 	cross build --bin anvil-zksync --target $* --release
 
+# Build the Rust project for a specific target (static build).
+build-static-%:
+	RUSTFLAGS='-C target-feature=+crt-static' OPENSSL_STATIC=1 cross build --bin anvil-zksync --target $* --release
+
 # Build the Rust documentation
 rust-doc:
 	cargo doc --no-deps --open


### PR DESCRIPTION
# What :computer: 
* fixes anvil-zksync failing on ubuntu-latest
* Updates cross.toml to use ubuntu-22.04 base image, and 
* Makes use of static builds for linux targets
* Bumps base image for release to ubuntu-latest (22.04)
* Closes #524 

# Why :hand:
* Previous release caused an issue when used with ubuntu 22.04, see #524 

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
