### PR TITLE
fix: destination path in refresh contracts script

### DIFF
--- a/scripts/refresh_contracts.sh
+++ b/scripts/refresh_contracts.sh
@@ -3,7 +3,7 @@ set -xe
 
 SRC_DIR=contracts/system-contracts/artifacts-zk/contracts-preprocessed
 DEV_CONTRACTS_SRC_DIR=contracts/l2-contracts/artifacts-zk/contracts/dev-contracts/
-DST_DIR=src/deps/contracts/
+DST_DIR=crates/core/src/deps/contracts/
 
 mkdir -p $DST_DIR
 


### PR DESCRIPTION
# What :computer: 
* Fixes the artifact destination path in `refresh_contracts.sh`

# Why :hand:
* Old path was still being used post crate-split.

# Evidence :camera:
Tested locally

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
