### PR TITLE
fix: anvil-zksync able to start even if the port is busy

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -15,7 +15,7 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
@@ -39,7 +39,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -55,7 +55,7 @@ jobs:
           tar -czf anvil-zksync-${{ matrix.os }}.tar.gz ./anvil-zksync*
 
       - name:  Upload artifact
-        uses:  actions/upload-artifact@v3
+        uses:  actions/upload-artifact@v4
         with:
           name: anvil-zksync-${{ matrix.os }}.tar.gz
           path: ./target/release/anvil-zksync-${{ matrix.os }}.tar.gz

--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/e2e-rust.yml
+++ b/.github/workflows/e2e-rust.yml
@@ -11,12 +11,12 @@ jobs:
         os: [ ubuntu-latest, macos-latest ]
     name: e2e-rust
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: anvil-zksync-${{ matrix.os }}.tar.gz
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,7 +22,7 @@ jobs:
           cache-dependency-path: 'e2e-tests/yarn.lock'
 
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: anvil-zksync-${{ matrix.os }}.tar.gz
       

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
     needs: [extract-version]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -99,7 +99,7 @@ jobs:
         # This is required to share artifacts between different jobs
         # =======================================================================
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: anvil-zksync-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.arch }}.tar.gz
           path: anvil-zksync-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.arch }}.tar.gz
@@ -121,7 +121,7 @@ jobs:
     steps:
       # This is necessary for generating the changelog. It has to come before "Download Artifacts" or else it deletes the artifacts.
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -129,7 +129,7 @@ jobs:
       #       Download artifacts
       # ==============================
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       # ==============================
       #       Create release draft

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -7,12 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     name: spec
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: "recursive"
 
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: anvil-zksync-ubuntu-latest.tar.gz
       

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,10 @@ lint-fix:
 	cd e2e-tests && yarn && yarn lint:fix && yarn fmt:fix
 	cargo clippy --fix
 	cargo fmt
+	cd e2e-tests-rust && cargo fmt --all
+	cd e2e-tests-rust && cargo clippy --fix
+	cd spec-tests && cargo fmt --all
+	cd spec-tests && cargo clippy --fix
 
 # Run unit tests for Rust code
 test:

--- a/crates/api_server/src/server.rs
+++ b/crates/api_server/src/server.rs
@@ -62,7 +62,7 @@ impl NodeServerBuilder {
         rpc
     }
 
-    pub async fn build(self, addr: SocketAddr) -> NodeServer {
+    pub async fn build(self, addr: SocketAddr) -> Result<NodeServer, String>  {
         let cors_layers = tower::util::option_layer(self.cors_enabled.then(|| {
             // `CorsLayer` adds CORS-specific headers to responses but does not do filtering by itself.
             // CORS relies on browsers respecting server's access list response headers.
@@ -86,14 +86,22 @@ impl NodeServerBuilder {
             )
             .set_rpc_middleware(RpcServiceBuilder::new().rpc_logger(100));
 
-        let server = server_builder.build(addr).await.unwrap();
-        let local_addr = server.local_addr().unwrap();
-        let rpc = Self::default_rpc(self.node);
-        // `jsonrpsee` does `tokio::spawn` within `start` method, so we cannot invoke it here, as this method
-        // should only build the server. This way we delay the launch until the `NodeServer::run` is invoked.
-        NodeServer {
-            local_addr,
-            run_fn: Box::new(move || server.start(rpc)),
+
+        match server_builder.build(addr).await {
+            Ok(server) => {
+                let local_addr = server.local_addr().unwrap();
+                let rpc = Self::default_rpc(self.node);
+                // `jsonrpsee` does `tokio::spawn` within `start` method, so we cannot invoke it here, as this method
+                // should only build the server. This way we delay the launch until the `NodeServer::run` is invoked.
+                Ok(NodeServer {
+                    local_addr,
+                    run_fn: Box::new(move || server.start(rpc)),
+                })
+            }
+            Err(e) => Err(format!(
+                "Failed to bind to address {}: {}",
+                addr, e
+            )),
         }
     }
 }

--- a/crates/api_server/src/server.rs
+++ b/crates/api_server/src/server.rs
@@ -62,7 +62,7 @@ impl NodeServerBuilder {
         rpc
     }
 
-    pub async fn build(self, addr: SocketAddr) -> Result<NodeServer, String>  {
+    pub async fn build(self, addr: SocketAddr) -> Result<NodeServer, String> {
         let cors_layers = tower::util::option_layer(self.cors_enabled.then(|| {
             // `CorsLayer` adds CORS-specific headers to responses but does not do filtering by itself.
             // CORS relies on browsers respecting server's access list response headers.
@@ -86,7 +86,6 @@ impl NodeServerBuilder {
             )
             .set_rpc_middleware(RpcServiceBuilder::new().rpc_logger(100));
 
-
         match server_builder.build(addr).await {
             Ok(server) => {
                 let local_addr = server.local_addr().unwrap();
@@ -98,10 +97,7 @@ impl NodeServerBuilder {
                     run_fn: Box::new(move || server.start(rpc)),
                 })
             }
-            Err(e) => Err(format!(
-                "Failed to bind to address {}: {}",
-                addr, e
-            )),
+            Err(e) => Err(format!("Failed to bind to address {}: {}", addr, e)),
         }
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -317,10 +317,40 @@ async fn main() -> anyhow::Result<()> {
     }
     let mut server_handles = Vec::with_capacity(config.host.len());
     for host in &config.host {
-        let addr = SocketAddr::new(*host, config.port);
-        let server = server_builder.clone().build(addr).await;
-        config.port = server.local_addr().port();
-        server_handles.push(server.run());
+        let mut addr = SocketAddr::new(*host, config.port);
+
+        match server_builder.clone().build(addr).await {
+            Ok(server) => {
+                config.port = server.local_addr().port();
+                server_handles.push(server.run());
+            }
+            Err(err) => {
+                tracing::info!(
+                    "Failed to bind to address {}:{}: {}. Retrying with a different port...",
+                    host, config.port, err
+                );
+
+                // Attempt to bind to a dynamic port
+                addr.set_port(0);
+                match server_builder.clone().build(addr).await {
+                    Ok(server) => {
+                        config.port = server.local_addr().port();
+                        tracing::info!(
+                            "Successfully started server on port {} for host {}",
+                            config.port, host
+                        );
+                        server_handles.push(server.run());
+                    }
+                    Err(err) => {
+                        return Err(anyhow!(
+                            "Failed to start server on host {} with port: {}",
+                            host,
+                            err
+                        ));
+                    }
+                }
+            }
+        }
     }
     let any_server_stopped =
         futures::future::select_all(server_handles.into_iter().map(|h| Box::pin(h.stopped())));

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -327,7 +327,9 @@ async fn main() -> anyhow::Result<()> {
             Err(err) => {
                 tracing::info!(
                     "Failed to bind to address {}:{}: {}. Retrying with a different port...",
-                    host, config.port, err
+                    host,
+                    config.port,
+                    err
                 );
 
                 // Attempt to bind to a dynamic port
@@ -337,7 +339,8 @@ async fn main() -> anyhow::Result<()> {
                         config.port = server.local_addr().port();
                         tracing::info!(
                             "Successfully started server on port {} for host {}",
-                            config.port, host
+                            config.port,
+                            host
                         );
                         server_handles.push(server.run());
                     }

--- a/crates/core/src/node/inner/in_memory_inner.rs
+++ b/crates/core/src/node/inner/in_memory_inner.rs
@@ -1628,7 +1628,7 @@ mod tests {
         let system_contracts = node
             .system_contracts
             .system_contracts_for_initiator(&node.impersonation, &tx.initiator_account());
-        let (block_ctx, batch_env, mut vm) = test_vm(&mut *node, system_contracts).await;
+        let (block_ctx, batch_env, mut vm) = test_vm(&mut node, system_contracts).await;
         let err = node
             .run_l2_tx(tx, 0, &block_ctx, &batch_env, &mut vm)
             .unwrap_err();
@@ -1647,7 +1647,7 @@ mod tests {
         let system_contracts = node
             .system_contracts
             .system_contracts_for_initiator(&node.impersonation, &tx.initiator_account());
-        let (block_ctx, batch_env, mut vm) = test_vm(&mut *node, system_contracts).await;
+        let (block_ctx, batch_env, mut vm) = test_vm(&mut node, system_contracts).await;
         let err = node
             .run_l2_tx(tx, 0, &block_ctx, &batch_env, &mut vm)
             .unwrap_err();
@@ -1670,7 +1670,7 @@ mod tests {
         let system_contracts = node
             .system_contracts
             .system_contracts_for_initiator(&node.impersonation, &tx.initiator_account());
-        let (block_ctx, batch_env, mut vm) = test_vm(&mut *node, system_contracts).await;
+        let (block_ctx, batch_env, mut vm) = test_vm(&mut node, system_contracts).await;
         let err = node
             .run_l2_tx(tx, 0, &block_ctx, &batch_env, &mut vm)
             .unwrap_err();
@@ -1740,7 +1740,7 @@ mod tests {
         let system_contracts = node
             .system_contracts
             .system_contracts_for_initiator(&node.impersonation, &tx.initiator_account());
-        let (_, _, mut vm) = test_vm(&mut *node, system_contracts).await;
+        let (_, _, mut vm) = test_vm(&mut node, system_contracts).await;
         node.run_l2_tx_raw(tx, &mut vm)
             .expect("transaction must pass with external storage");
     }
@@ -1790,7 +1790,7 @@ mod tests {
         let system_contracts = node
             .system_contracts
             .system_contracts_for_initiator(&node.impersonation, &tx.initiator_account());
-        let (_, _, mut vm) = test_vm(&mut *node, system_contracts).await;
+        let (_, _, mut vm) = test_vm(&mut node, system_contracts).await;
         let TxExecutionOutput { result, .. } = node.run_l2_tx_raw(tx, &mut vm).expect("failed tx");
 
         match result.result {

--- a/e2e-tests-rust/Cargo.lock
+++ b/e2e-tests-rust/Cargo.lock
@@ -941,6 +941,8 @@ version = "0.0.0"
 dependencies = [
  "alloy",
  "alloy-zksync",
+ "anvil_zksync_api_server",
+ "anvil_zksync_config",
  "anvil_zksync_core",
  "anyhow",
  "async-trait",
@@ -956,6 +958,37 @@ dependencies = [
  "tempdir",
  "tokio",
  "tower 0.5.1",
+ "tower-http",
+]
+
+[[package]]
+name = "anvil_zksync_api_decl"
+version = "0.2.4"
+dependencies = [
+ "anvil_zksync_types",
+ "jsonrpsee",
+ "zksync_types",
+ "zksync_web3_decl",
+]
+
+[[package]]
+name = "anvil_zksync_api_server"
+version = "0.2.4"
+dependencies = [
+ "anvil_zksync_api_decl",
+ "anvil_zksync_core",
+ "anvil_zksync_types",
+ "anyhow",
+ "hex",
+ "http 1.1.0",
+ "jsonrpsee",
+ "thiserror 1.0.69",
+ "tokio",
+ "tower 0.4.13",
+ "tower-http",
+ "tracing",
+ "zksync_types",
+ "zksync_web3_decl",
 ]
 
 [[package]]
@@ -6281,6 +6314,20 @@ dependencies = [
  "futures-util",
  "pin-project-lite",
  "sync_wrapper 0.1.2",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
+dependencies = [
+ "bitflags 2.6.0",
+ "bytes",
+ "http 1.1.0",
+ "pin-project-lite",
  "tower-layer",
  "tower-service",
 ]

--- a/e2e-tests-rust/Cargo.lock
+++ b/e2e-tests-rust/Cargo.lock
@@ -941,8 +941,6 @@ version = "0.0.0"
 dependencies = [
  "alloy",
  "alloy-zksync",
- "anvil_zksync_api_server",
- "anvil_zksync_config",
  "anvil_zksync_core",
  "anyhow",
  "async-trait",
@@ -959,36 +957,6 @@ dependencies = [
  "tokio",
  "tower 0.5.1",
  "tower-http",
-]
-
-[[package]]
-name = "anvil_zksync_api_decl"
-version = "0.2.4"
-dependencies = [
- "anvil_zksync_types",
- "jsonrpsee",
- "zksync_types",
- "zksync_web3_decl",
-]
-
-[[package]]
-name = "anvil_zksync_api_server"
-version = "0.2.4"
-dependencies = [
- "anvil_zksync_api_decl",
- "anvil_zksync_core",
- "anvil_zksync_types",
- "anyhow",
- "hex",
- "http 1.1.0",
- "jsonrpsee",
- "thiserror 1.0.69",
- "tokio",
- "tower 0.4.13",
- "tower-http",
- "tracing",
- "zksync_types",
- "zksync_web3_decl",
 ]
 
 [[package]]

--- a/e2e-tests-rust/Cargo.toml
+++ b/e2e-tests-rust/Cargo.toml
@@ -25,8 +25,6 @@ tower = "0.5"
 http = "1.1.0"
 tower-http = { version = "0.6.2", features = ["cors"] }
 anvil_zksync_core = { path = "../crates/core" }
-anvil_zksync_api_server = { path = "../crates/api_server" }
-anvil_zksync_config = { path = "../crates/config" }
 tempdir = "0.3.7"
 flate2 = "1.0"
 hex = "0.4"

--- a/e2e-tests-rust/Cargo.toml
+++ b/e2e-tests-rust/Cargo.toml
@@ -23,7 +23,6 @@ reqwest-middleware = { version = "0.4", features = ["json"] }
 serde_json = "1"
 tower = "0.5"
 http = "1.1.0"
-tower-http = { version = "0.6.2", features = ["cors"] }
 anvil_zksync_core = { path = "../crates/core" }
 tempdir = "0.3.7"
 flate2 = "1.0"

--- a/e2e-tests-rust/Cargo.toml
+++ b/e2e-tests-rust/Cargo.toml
@@ -23,7 +23,10 @@ reqwest-middleware = { version = "0.4", features = ["json"] }
 serde_json = "1"
 tower = "0.5"
 http = "1.1.0"
+tower-http = { version = "0.6.2", features = ["cors"] }
 anvil_zksync_core = { path = "../crates/core" }
+anvil_zksync_api_server = { path = "../crates/api_server" }
+anvil_zksync_config = { path = "../crates/config" }
 tempdir = "0.3.7"
 flate2 = "1.0"
 hex = "0.4"

--- a/e2e-tests-rust/src/lib.rs
+++ b/e2e-tests-rust/src/lib.rs
@@ -10,4 +10,4 @@ pub use provider::{
     init_testing_provider, init_testing_provider_with_client, AnvilZKsyncApi, TestingProvider,
     DEFAULT_TX_VALUE,
 };
-pub use utils::get_node_binary_path;
+pub use utils::{get_node_binary_path, LockedPort};

--- a/e2e-tests-rust/tests/lib.rs
+++ b/e2e-tests-rust/tests/lib.rs
@@ -5,9 +5,7 @@ use alloy::{
     network::primitives::BlockTransactionsKind, primitives::U256, signers::local::PrivateKeySigner,
 };
 use alloy_zksync::node_bindings::AnvilZKsync;
-use anvil_zksync_api_server::NodeServerBuilder;
-use anvil_zksync_config::TestNodeConfig;
-use anvil_zksync_core::node::{InMemoryNode, VersionedState};
+use anvil_zksync_core::node::VersionedState;
 use anvil_zksync_core::utils::write_json_file;
 use anvil_zksync_e2e_tests::{
     get_node_binary_path, init_testing_provider, init_testing_provider_with_client, AnvilZKsyncApi,
@@ -20,10 +18,8 @@ use http::header::{
     ACCESS_CONTROL_ALLOW_ORIGIN, ORIGIN,
 };
 use std::io::Read;
-use std::net::SocketAddr;
 use std::{convert::identity, fs, thread::sleep, time::Duration};
 use tempdir::TempDir;
-use tower_http::cors::AllowOrigin;
 
 const SOME_ORIGIN: HeaderValue = HeaderValue::from_static("http://some.origin");
 const OTHER_ORIGIN: HeaderValue = HeaderValue::from_static("http://other.origin");


### PR DESCRIPTION
# What :computer: 
* fixes: anvil-zksync able to start even if the port is busy, Closes #512 
* Bump CI versions for upload / download artifacts. See:
```
deprecated version of `actions/download-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
```

# Why :hand:
* Should be able to use fallback port if busy without panic

# Evidence :camera:

![Screenshot 2025-01-16 at 10 04 52 AM](https://github.com/user-attachments/assets/f87ef5a4-ef2d-4722-8855-7efaf1a49474)

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
