### PR TITLE
fix: Spawn `NodeExecutor` before applying replay transactions

### DIFF
--- a/crates/core/src/node/in_memory.rs
+++ b/crates/core/src/node/in_memory.rs
@@ -337,12 +337,12 @@ impl InMemoryNode {
                 .iter()
                 .map(|tx| tx.hash())
                 .collect::<HashSet<_>>();
-            let block_numer = self.node_handle.seal_block_sync(tx_batch).await?;
+            let block_number = self.node_handle.seal_block_sync(tx_batch).await?;
 
             // Fetch the block that was just sealed
             let block = self
                 .blockchain
-                .get_block_by_number(block_numer)
+                .get_block_by_number(block_number)
                 .await
                 .expect("freshly sealed block could not be found in storage");
 


### PR DESCRIPTION
# What :computer: 
* Spawn `NodeExecutor` before applying replay transactions in `main.rs`
* Closes #543 

# Why :hand:
* When making use of `replay_tx` we were sending a command over a channel and then waiting for a response but the `NodeExecutor` had not been started yet, so it never read that command or sent back a reply which caused the node to hang.

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

```
./target/release/anvil-zksync --reset-cache=true --cache=none replay_tx --fork-url mainnet 0x4f8a6c93fee26a3dd01ee0c92f0adeb78960ba36b20b24de61392983234e60dd
20:40:41  INFO 
20:40:41  INFO Validating 0x6dbfcea28c98a8ee26a3688436c29be3579f70adb90ee801eaee976e7b364996
20:40:41  INFO Executing 0x6dbfcea28c98a8ee26a3688436c29be3579f70adb90ee801eaee976e7b364996
20:40:44  INFO 
20:40:44  INFO ✅  [SUCCESS] Hash: 0x6dbfcea28c98a8ee26a3688436c29be3579f70adb90ee801eaee976e7b364996
20:40:44  INFO Initiator: 0x29fe51e7faeca871ce07a790bac48bbc1c9868fb
20:40:44  INFO Payer: 0x29fe51e7faeca871ce07a790bac48bbc1c9868fb
20:40:44  INFO Gas Limit: 3_000_000 | Used: 273_310 | Refunded: 2_726_690
20:40:44  INFO Paid: 0.0000123673 ETH (273310 gas * 0.04525000 gwei)
20:40:44  INFO Refunded: 0.0001233827 ETH
20:40:44  INFO 
20:40:44  INFO 
20:40:44  INFO Validating 0x4f8a6c93fee26a3dd01ee0c92f0adeb78960ba36b20b24de61392983234e60dd
20:40:44  INFO Executing 0x4f8a6c93fee26a3dd01ee0c92f0adeb78960ba36b20b24de61392983234e60dd
20:40:46  INFO 
20:40:46  INFO ✅  [SUCCESS] Hash: 0x4f8a6c93fee26a3dd01ee0c92f0adeb78960ba36b20b24de61392983234e60dd
20:40:46  INFO Initiator: 0x03ac0b1b952c643d66a4dc1fbc75118109cc074c
20:40:46  INFO Payer: 0x03ac0b1b952c643d66a4dc1fbc75118109cc074c
20:40:46  INFO Gas Limit: 1_000_000 | Used: 313_047 | Refunded: 686_953
20:40:46  INFO Paid: 0.0000141654 ETH (313047 gas * 0.04525000 gwei)
20:40:46  INFO Refunded: 0.0000310846 ETH
```

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
