### PR TITLE
feat: [zkos] change witness from Vec<u8> to hex string

### DIFF
--- a/crates/api_decl/src/namespaces/zkos.rs
+++ b/crates/api_decl/src/namespaces/zkos.rs
@@ -9,5 +9,5 @@ pub trait ZKOSNamespace {
     /// # Returns
     /// Bytes with the witness that can be passed to proving system.
     #[method(name = "getWitness")]
-    async fn get_witness(&self, batch: u32) -> RpcResult<Option<Vec<u8>>>;
+    async fn get_witness(&self, batch: u32) -> RpcResult<Option<String>>;
 }

--- a/crates/api_server/src/impls/zkos.rs
+++ b/crates/api_server/src/impls/zkos.rs
@@ -13,7 +13,7 @@ impl ZKOSNamespace {
 
 #[async_trait]
 impl ZKOSNamespaceServer for ZKOSNamespace {
-    async fn get_witness(&self, batch: u32) -> RpcResult<Option<Vec<u8>>> {
-        Ok(zkos_get_batch_witness(&batch))
+    async fn get_witness(&self, batch: u32) -> RpcResult<Option<String>> {
+        Ok(zkos_get_batch_witness(&batch).map(|data| hex::encode(data)))
     }
 }


### PR DESCRIPTION
# What :computer: 
* changed witness to return data as hex string - to make it easier to pass to downstream tools
