### PR TITLE
feat(cli)!: replay transactions when forking at a tx hash

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -1,6 +1,6 @@
 name: Check PR title
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - reopened
@@ -12,7 +12,38 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       statuses: write
+      pull-requests: write
     steps:
-      - uses: aslafy-z/conventional-pr-title-action@v3
+      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5
+        id: lint_pr_title
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2
+        # When the previous steps fails, the workflow would stop. By adding this
+        # condition you can continue the execution with the populated error message.
+        if: always() && (steps.lint_pr_title.outputs.error_message != null)
+        with:
+          header: pr-title-lint-error
+          message: |
+            Hey there! 👋🏼
+            
+            We require pull request titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) and it looks like your proposed title needs to be adjusted.
+            Examples of valid PR titles:
+
+            - feat(cli): Support new command option
+            - fix(core): Correctly handle edge case
+            - ci: Add new workflow for linting
+
+            Details:
+            
+            ```
+            ${{ steps.lint_pr_title.outputs.error_message }}
+            ```
+
+      # Delete a previous comment when the issue has been resolved
+      - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
+        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2
+        with:
+          header: pr-title-lint-error
+          delete: true

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -119,9 +119,7 @@ async fn main() -> anyhow::Result<()> {
             }
         }
         Command::Fork(fork) => {
-            // TODO: For now, we do not replay earlier transactions when forking to keep compatibility
-            //       with the legacy forking behavior.
-            let (fork_client, _) = if let Some(tx_hash) = fork.fork_transaction_hash {
+            let (fork_client, earlier_txs) = if let Some(tx_hash) = fork.fork_transaction_hash {
                 // If transaction hash is provided, we fork at the parent of block containing tx
                 ForkClient::at_before_tx(fork.fork_url.to_config(), tx_hash).await?
             } else {
@@ -137,7 +135,7 @@ async fn main() -> anyhow::Result<()> {
             };
 
             update_with_fork_details(&mut config, &fork_client.details).await;
-            (Some(fork_client), Vec::new())
+            (Some(fork_client), earlier_txs)
         }
         Command::ReplayTx(replay_tx) => {
             let (fork_client, earlier_txs) =


### PR DESCRIPTION
# What :computer: 

This PR changes behaviour of `anvil-zksync fork --fork-url <url> --fork-transaction-hash <hash>`:
**Before**: fork is initialized at the parent of the block containing provided tx hash, earlier transactions **are not** replayed
**Now**: fork is initialized at the parent of the block containing provided tx hash, earlier transactions **are** replayed

# Why :hand:
This better aligns to what I would expect to happen but admittedly this is a breaking change
