### PR TITLE
chore: update release token to enable ci in release PRs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,7 +23,7 @@ jobs:
     uses: matter-labs/zksync-ci-common/.github/workflows/release-please.yaml@v1
     secrets:
       slack_webhook: ${{ secrets.SLACK_WEBHOOK }}
-      gh_token: ${{ secrets.GITHUB_TOKEN }}
+      gh_token: ${{ secrets.RELEASE_TOKEN }}
     with:
       config: '.github/release-please/config.json'     # Specify the path to the configuration file
       manifest: '.github/release-please/manifest.json' # Specify the path to the manifest file


### PR DESCRIPTION
# What :computer: 

Update release token.

# Why :hand:

To enable CI in release PRs.