### PR TITLE
ci: fix packaging issue for anvil-zksync tar archives

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,8 +61,9 @@ jobs:
 
       - name: Pack anvil-zksync
         run: |
-          tar -czf anvil-zksync-${{ inputs.tag || inputs.prerelease_name }}-${{ matrix.arch }}.tar.gz \
-            ./target/${{ matrix.arch }}/release/anvil-zksync
+          tar -C ./target/${{ matrix.arch }}/release -czf \
+            anvil-zksync-${{ inputs.tag || inputs.prerelease_name }}-${{ matrix.arch }}.tar.gz \
+            anvil-zksync
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -93,7 +94,7 @@ jobs:
         shell: 'bash -ex {0}'
         run: |
           [ ! -z "${{ inputs.tag }}" ] && TAG="${{ inputs.tag }}" \
-            || TAG="$(git rev-parse --short HEAD)" 
+            || TAG="$(git rev-parse --short HEAD)"
           echo "tag=${TAG}" >> "${GITHUB_OUTPUT}"
 
       - name: Download artifacts


### PR DESCRIPTION
# What :computer: 

Fix packaging issue for `anvil-zksync` executable in tar.gz archive.

Release `v0.3.0` is already fixed.

# Why :hand:

Last CI changed the packaging way resulting in nested directories `target/arch/release/` to be packed inside the `tar` archive which broke Hardhat integration as it expects exactly one file in the archive.
