### PR TITLE
fix: refrain from starting server during tx replay

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -279,6 +279,9 @@ async fn main() -> anyhow::Result<()> {
     if !transactions_to_replay.is_empty() {
         node.apply_txs(transactions_to_replay, config.max_transactions)
             .await?;
+
+        // If we are in replay mode, we don't start the server
+        return Ok(());
     }
 
     // TODO: Consider moving to `InMemoryNodeInner::init`


### PR DESCRIPTION
# What :computer: 
* refrain from starting server during tx replay

# Why :hand:
* Closes #521 

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

```
./target/release/anvil-zksync replay_tx --fork-url https://api.testnet.abs.xyz 0xce7b0578808283cad26cba971e1ab814e48aeb20041b925691d2b484f3b06ae7

❌ [FAILED] Hash: 0xce7b0578808283cad26cba971e1ab814e48aeb20041b925691d2b484f3b06ae7
Initiator: 0xe0a5b54fd2f4628250294415c9f49ceed725e722
Payer: 0xe0a5b54fd2f4628250294415c9f49ceed725e722
Gas Limit: 450_000 | Used: 262_460 | Refunded: 187_540
Paid: 0.0000065615 ETH (262460 gas * 0.02500000 gwei)
Refunded: 0.0000046885 ETH
```

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
