### PR TITLE
fix: 404 links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
       url: https://github.com/zkSync-Community-Hub/zkync-developers/discussions
       about: Please provide feedback, and ask questions here.
     - name: In-memory documentation page
-      url: https://era.zksync.io/docs/tools/testing/anvil-zksync.html
+      url: https://docs.zksync.io/zksync-era/tooling/local-setup/anvil-zksync-node
       about: Please refer to the documentation for immediate answers.

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -35,7 +35,7 @@
 //! ## Usage
 //!
 //! To start the node, use the command `anvil-zksync run`. For more advanced functionalities like forking or
-//! replaying transactions, refer to the [official documentation](https://era.zksync.io/docs/tools/testing/anvil-zksync.html).
+//! replaying transactions, refer to the [official documentation](https://docs.zksync.io/zksync-era/tooling/local-setup/anvil-zksync-node).
 //!
 //! ## Contributions
 //!

--- a/docs/rustbook/src/usage/testing.md
+++ b/docs/rustbook/src/usage/testing.md
@@ -32,7 +32,7 @@ RUST_LOG=vm=trace anvil-zksync --dev-use-local-contracts fork sepolia-testnet
 This section demonstrates how to author and execute tests locally against `anvil-zksync` using the `mocha` and `chai` testing frameworks.
 
 ### Project configuration
-Start by creating a new Hardhat project. If you need guidance, follow the [getting started guide](https://era.zksync.io/docs/tools/hardhat/getting-started.html).
+Start by creating a new Hardhat project. If you need guidance, follow the [getting started guide](https://docs.zksync.io/zksync-era/tooling/hardhat/guides/getting-started).
 
 To incorporate the test libraries, execute:
 ```sh


### PR DESCRIPTION
# What :computer: 
Hi! I updated a 404 links in 
- `.github/ISSUE_TEMPLATE/config.yml.`
- `crates/core/src/lib.rs.`
- `docs/rustbook/src/usage/testing.md.`

# Why :hand:
- The old links pointing to era.zksync.io/docs/ were no longer valid.
- Updated links now point to the correct documentation at docs.zksync.io/zksync-era.

