### PR TITLE
chore: add cargo-deny

### DIFF
--- a/.github/workflows/cargo-license.yaml
+++ b/.github/workflows/cargo-license.yaml
@@ -1,0 +1,12 @@
+name: cargo-deny check
+on: pull_request
+jobs:
+  cargo-deny:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: EmbarkStudios/cargo-deny-action@v2
+      with:
+        manifest-path: "./Cargo.toml"
+        command: check
+        command-arguments: "--hide-inclusion-graph"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1062,7 +1062,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "tempdir",
+ "tempfile",
  "tokio",
  "tower 0.4.13",
  "tower-http",
@@ -1165,7 +1165,7 @@ dependencies = [
  "rustc-hash 1.1.0",
  "serde",
  "serde_json",
- "tempdir",
+ "tempfile",
  "test-case",
  "thiserror 1.0.69",
  "time",
@@ -1195,7 +1195,7 @@ dependencies = [
  "serde",
  "serde_with",
  "serde_yaml",
- "tempdir",
+ "tempfile",
  "tokio",
  "tracing",
  "zksync_contracts",
@@ -4232,6 +4232,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5450,7 +5462,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -6877,15 +6889,6 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "reqwest"
@@ -8401,23 +8404,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand 0.4.6",
- "remove_dir_all",
-]
-
-[[package]]
 name = "tempfile"
-version = "3.14.0"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
+checksum = "38c246215d7d24f48ae091a2902398798e05d978b24315d6efbc00ede9a8bb91"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "getrandom 0.3.1",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -9390,6 +9384,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9558,7 +9561,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -9789,6 +9792,15 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -10418,7 +10430,7 @@ dependencies = [
 [[package]]
 name = "zksync_telemetry"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-telemetry.git?rev=ed600f46c74ccc15ae34ea38f27327d66458518a#ed600f46c74ccc15ae34ea38f27327d66458518a"
+source = "git+https://github.com/matter-labs/zksync-telemetry.git?rev=d5c35951843263765079545c31c908dcbaab1f30#d5c35951843263765079545c31c908dcbaab1f30"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ zksync_contracts = { git = "https://github.com/matter-labs/zksync-era", tag = "c
 zksync_types = { git = "https://github.com/matter-labs/zksync-era", tag = "core-v26.4.0" }
 zksync_vm_interface = { git = "https://github.com/matter-labs/zksync-era", tag = "core-v26.4.0" }
 zksync_web3_decl = { git = "https://github.com/matter-labs/zksync-era", tag = "core-v26.4.0" }
-zksync_telemetry = { git = "https://github.com/matter-labs/zksync-telemetry.git", rev = "ed600f46c74ccc15ae34ea38f27327d66458518a" }
+zksync_telemetry = { git = "https://github.com/matter-labs/zksync-telemetry.git", rev = "d5c35951843263765079545c31c908dcbaab1f30" }
 zksync-error-codegen = { git = "https://github.com/matter-labs/zksync-error", rev = "92d1b60d18686e0e261f04dc7efd74db60e112f1", default-features = false }
 zksync-error-description = { git = "https://github.com/matter-labs/zksync-error", rev = "92d1b60d18686e0e261f04dc7efd74db60e112f1" }
 
@@ -72,7 +72,7 @@ serde_json = "1.0"
 strum = "0.26.3"
 strum_macros = "0.26.4"
 serde_yaml = "0.9.33"
-tempdir = "0.3.7"
+tempfile = { version = "3.16.0", default-features = false }
 thiserror = "1"
 time = "0.3.36"
 tokio = { version = "1", features = ["full", "tracing"] }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -42,4 +42,4 @@ flate2.workspace = true
 url.workspace = true
 
 [dev-dependencies]
-tempdir.workspace = true
+tempfile.workspace = true

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -866,7 +866,6 @@ mod tests {
         env,
         net::{IpAddr, Ipv4Addr},
     };
-    use tempdir::TempDir;
     use zksync_types::{H160, U256};
 
     #[test]
@@ -915,7 +914,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_dump_state() -> anyhow::Result<()> {
-        let temp_dir = TempDir::new("state-test").expect("failed creating temporary dir");
+        let temp_dir = tempfile::Builder::new()
+            .prefix("state-test")
+            .tempdir()
+            .expect("failed creating temporary dir");
         let dump_path = temp_dir.path().join("state.json");
 
         let config = anvil_zksync_config::TestNodeConfig {
@@ -956,7 +958,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_load_state() -> anyhow::Result<()> {
-        let temp_dir = TempDir::new("state-load-test").expect("failed creating temporary dir");
+        let temp_dir = tempfile::Builder::new()
+            .prefix("state-load-test")
+            .tempdir()
+            .expect("failed creating temporary dir");
         let state_path = temp_dir.path().join("state.json");
 
         let config = anvil_zksync_config::TestNodeConfig {

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -49,7 +49,7 @@ url.workspace = true
 [dev-dependencies]
 maplit.workspace = true
 httptest.workspace = true
-tempdir.workspace = true
+tempfile.workspace = true
 test-case.workspace = true
 backon.workspace = true
 

--- a/crates/core/src/cache.rs
+++ b/crates/core/src/cache.rs
@@ -377,7 +377,6 @@ impl Cache {
 
 #[cfg(test)]
 mod tests {
-    use tempdir::TempDir;
     use zksync_types::{Execute, ExecuteTransactionCommon};
     use zksync_types::{H160, U64};
 
@@ -504,7 +503,10 @@ mod tests {
             l2_legacy_shared_bridge: Some(H160::repeat_byte(0x6)),
         };
 
-        let cache_dir = TempDir::new("cache-test").expect("failed creating temporary dir");
+        let cache_dir = tempfile::Builder::new()
+            .prefix("cache-test")
+            .tempdir()
+            .expect("failed creating temporary dir");
         let cache_dir_path = cache_dir
             .path()
             .to_str()
@@ -605,7 +607,10 @@ mod tests {
             l2_legacy_shared_bridge: Some(H160::repeat_byte(0x6)),
         };
 
-        let cache_dir = TempDir::new("cache-test").expect("failed creating temporary dir");
+        let cache_dir = tempfile::Builder::new()
+            .prefix("cache-test")
+            .tempdir()
+            .expect("failed creating temporary dir");
         let cache_dir_path = cache_dir
             .path()
             .to_str()
@@ -660,7 +665,10 @@ mod tests {
 
     #[test]
     fn test_cache_config_disk_only_resets_created_data_on_disk() {
-        let cache_dir = TempDir::new("cache-test").expect("failed creating temporary dir");
+        let cache_dir = tempfile::Builder::new()
+            .prefix("cache-test")
+            .tempdir()
+            .expect("failed creating temporary dir");
         let cache_dir_path = cache_dir
             .path()
             .to_str()

--- a/crates/l1_sidecar/Cargo.toml
+++ b/crates/l1_sidecar/Cargo.toml
@@ -21,7 +21,7 @@ alloy = { workspace = true, default-features = false, features = ["sol-types", "
 foundry-anvil.workspace = true
 foundry-common.workspace = true
 anyhow.workspace = true
-tempdir.workspace = true
+tempfile.workspace = true
 serde.workspace = true
 serde_yaml.workspace = true
 serde_with.workspace = true

--- a/crates/l1_sidecar/src/anvil.rs
+++ b/crates/l1_sidecar/src/anvil.rs
@@ -5,7 +5,7 @@ use anyhow::Context;
 use foundry_anvil::{NodeConfig, NodeHandle};
 use foundry_common::Shell;
 use std::time::Duration;
-use tempdir::TempDir;
+use tempfile::TempDir;
 use tokio::io::AsyncWriteExt;
 
 /// Representation of an anvil process spawned onto an event loop.
@@ -34,7 +34,9 @@ pub async fn spawn_builtin(
     port: u16,
     zkstack_config: &ZkstackConfig,
 ) -> anyhow::Result<(AnvilHandle, Box<dyn Provider>)> {
-    let tmpdir = TempDir::new("anvil_zksync_l1")?;
+    let tmpdir = tempfile::Builder::new()
+        .prefix("anvil_zksync_l1")
+        .tempdir()?;
     let anvil_state_path = tmpdir.path().join("l1-state.json");
     let mut anvil_state_file = tokio::fs::File::create(&anvil_state_path).await?;
     anvil_state_file

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,78 @@
+[graph]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "aarch64-apple-darwin",
+]
+all-features = false
+no-default-features = false
+
+[output]
+feature-depth = 1
+
+[advisories]
+ignore = [
+    { id = "RUSTSEC-2024-0370", reason = "`proc-macro-error` is unmaintained, but foundry relies on it" },
+    { id = "RUSTSEC-2024-0388", reason = '`derivative` is unmaintained, crypto dependenicies (boojum, circuit_encodings and others) rely on it' },
+]
+
+[licenses]
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "ISC",
+    "Unlicense",
+    "MPL-2.0",
+    "CC0-1.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "Zlib",
+    "OpenSSL",
+    "Apache-2.0 WITH LLVM-exception",
+    "0BSD",
+    "BSL-1.0",
+    "Unicode-3.0"
+]
+confidence-threshold = 0.8
+
+[[licenses.clarify]]
+crate = "ring"
+# SPDX considers OpenSSL to encompass both the OpenSSL and SSLeay licenses
+# https://spdx.org/licenses/OpenSSL.html
+# ISC - Both BoringSSL and ring use this for their new files
+# MIT - "Files in third_party/ have their own licenses, as described therein. The MIT
+# license, for third_party/fiat, which, unlike other third_party directories, is
+# compiled into non-test libraries, is included below."
+# OpenSSL - Obviously
+expression = "ISC AND MIT AND OpenSSL"
+license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
+
+[licenses.private]
+ignore = false
+registries = []
+
+[bans]
+multiple-versions = "allow"
+wildcards = "allow"
+highlight = "all"
+workspace-default-features = "allow"
+external-default-features = "allow"
+allow = []
+deny = [
+    { crate = "openssl", use-instead = "rustls" },
+    { crate = "openssl-sys", use-instead = "rustls" },
+]
+skip = []
+skip-tree = []
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "allow"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []
+
+[sources.allow-org]
+github = []
+gitlab = []
+bitbucket = []


### PR DESCRIPTION
# What :computer: 
This PR migrates from tempdir (unmaintaned) to tempfile and enforces cargo-deny check that forbids openssl

# Why :hand:

