### PR TITLE
refactor: enforce block base fee through `NodeExecutor`

### DIFF
--- a/crates/core/src/node/in_memory_ext.rs
+++ b/crates/core/src/node/in_memory_ext.rs
@@ -368,12 +368,9 @@ impl InMemoryNode {
     }
 
     pub async fn set_next_block_base_fee_per_gas(&self, base_fee: U256) -> Result<()> {
-        self.inner
-            .write()
+        self.node_handle
+            .enforce_next_base_fee_per_gas_sync(base_fee)
             .await
-            .fee_input_provider
-            .set_base_fee(base_fee.as_u64());
-        Ok(())
     }
 
     pub async fn set_rpc_url(&self, url: String) -> Result<()> {


### PR DESCRIPTION
# What :computer: 
Makes fee enforcement go through `NodeExecutor`. Once we allow multiple blocks per batch (see https://github.com/matter-labs/anvil-zksync/issues/363) it won't make sense to be able to change base fee on the fly without regard for `NodeExecutor` as you have to force seal a batch to change base fee.

# Why :hand:
Future proofing for the upcoming `BatchExecutor` major refactoring