### PR TITLE
chore: fix Docker builds on rustup 1.28.0

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+# Ignore everything by default
+*
+
+# Allow files needed to build anvil-zksync
+!crates
+!l1-setup/configs
+!l1-setup/state
+!l1-setup/wallets.yaml
+!Cargo.toml
+!Cargo.lock
+!rust-toolchain.toml
+!etc/errors

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ WORKDIR /anvil-zksync
 
 FROM chef AS planner
 COPY . .
+# Mitigate rustup 1.28.0's new behavior https://blog.rust-lang.org/2025/03/02/Rustup-1.28.0.html
+# Supposedly, it will be rolled back in the next patch release https://github.com/rust-lang/rustup/pull/4214
+RUN rustup show active-toolchain || rustup toolchain install
 RUN cargo chef prepare --recipe-path recipe.json
 
 FROM chef AS builder
@@ -11,6 +14,9 @@ COPY --from=planner /anvil-zksync/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json
 # Build application
 COPY . .
+# Mitigate rustup 1.28.0's new behavior https://blog.rust-lang.org/2025/03/02/Rustup-1.28.0.html
+# Supposedly, it will be rolled back in the next patch release https://github.com/rust-lang/rustup/pull/4214
+RUN rustup show active-toolchain || rustup toolchain install
 RUN cargo build --release --bin anvil-zksync
 
 FROM ubuntu:24.04 AS runtime


### PR DESCRIPTION
# What :computer: 
Ditto, temporary measure before 1.28.1/1.28.2 makes it into `cargo-chef`'s latest Docker image

# Why :hand:
CI is borked