### PR TITLE
refactor: migrate node errors 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1174,7 +1174,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "zksync-error-codegen",
- "zksync-error-description",
+ "zksync-error-description 0.1.0 (git+https://github.com/matter-labs/zksync-error?rev=5d4783b83291b63f5fd1cbf5647fdbfd9fabc070)",
  "zksync_contracts",
  "zksync_error",
  "zksync_mini_merkle_tree",
@@ -10162,7 +10162,6 @@ dependencies = [
 [[package]]
 name = "zksync-error-codegen"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-error?rev=76e8e471b048461d2754092fa159c87a47db5972#76e8e471b048461d2754092fa159c87a47db5972"
 dependencies = [
  "cargo_metadata",
  "derive_more 2.0.1",
@@ -10182,14 +10181,13 @@ dependencies = [
  "thiserror 1.0.69",
  "tracing",
  "vector-map",
- "zksync-error-description",
+ "zksync-error-description 0.1.0",
  "zksync-error-model",
 ]
 
 [[package]]
 name = "zksync-error-description"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-error?rev=76e8e471b048461d2754092fa159c87a47db5972#76e8e471b048461d2754092fa159c87a47db5972"
 dependencies = [
  "serde",
  "serde_json",
@@ -10197,9 +10195,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "zksync-error-description"
+version = "0.1.0"
+source = "git+https://github.com/matter-labs/zksync-error?rev=5d4783b83291b63f5fd1cbf5647fdbfd9fabc070#5d4783b83291b63f5fd1cbf5647fdbfd9fabc070"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "zksync-error-model"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-error?rev=76e8e471b048461d2754092fa159c87a47db5972#76e8e471b048461d2754092fa159c87a47db5972"
 dependencies = [
  "derive_more 2.0.1",
  "serde",
@@ -10340,7 +10346,8 @@ dependencies = [
  "serde_json",
  "strum",
  "strum_macros",
- "zksync-error-description",
+ "zksync-error-description 0.1.0 (git+https://github.com/matter-labs/zksync-error?rev=5d4783b83291b63f5fd1cbf5647fdbfd9fabc070)",
+ "zksync_types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,8 +40,8 @@ zksync_types = { git = "https://github.com/matter-labs/zksync-era", tag = "core-
 zksync_vm_interface = { git = "https://github.com/matter-labs/zksync-era", tag = "core-v26.4.0" }
 zksync_web3_decl = { git = "https://github.com/matter-labs/zksync-era", tag = "core-v26.4.0" }
 zksync_telemetry = { git = "https://github.com/matter-labs/zksync-telemetry.git", rev = "d5c35951843263765079545c31c908dcbaab1f30" }
-zksync-error-codegen = { git = "https://github.com/matter-labs/zksync-error", rev = "76e8e471b048461d2754092fa159c87a47db5972", default-features = false }
-zksync-error-description = { git = "https://github.com/matter-labs/zksync-error", rev = "76e8e471b048461d2754092fa159c87a47db5972" }
+zksync-error-codegen = { git = "https://github.com/matter-labs/zksync-error", rev = "5d4783b83291b63f5fd1cbf5647fdbfd9fabc070", default-features = false }
+zksync-error-description = { git = "https://github.com/matter-labs/zksync-error", rev = "5d4783b83291b63f5fd1cbf5647fdbfd9fabc070" }
 
 #########################
 # External dependencies #
@@ -110,3 +110,6 @@ anvil_zksync_l1_sidecar = { path = "crates/l1_sidecar" }
 anvil_zksync_types = { path = "crates/types" }
 anvil_zksync_common = { path = "crates/common" }
 zksync_error = { path = "crates/zksync_error" }
+
+[patch."https://github.com/matter-labs/zksync-error"]
+zksync-error-codegen = { path = "../devex/zksync-error/crates/zksync-error-codegen" }

--- a/crates/api_server/src/error.rs
+++ b/crates/api_server/src/error.rs
@@ -1,5 +1,6 @@
 use anvil_zksync_core::node::error::LoadStateError;
 use jsonrpsee::types::{ErrorCode, ErrorObjectOwned};
+use zksync_error::anvil_zksync::node::AnvilNodeError;
 use zksync_web3_decl::error::Web3Error;
 
 #[derive(thiserror::Error, Debug)]
@@ -10,6 +11,8 @@ pub enum RpcError {
     Unsupported,
     #[error("{0}")]
     Web3Error(#[from] Web3Error),
+    #[error("{0}")]
+    NodeError(#[from] AnvilNodeError),
     // TODO: Shouldn't exist once we create a proper error hierarchy
     #[error("internal error: {0}")]
     Other(#[from] anyhow::Error),
@@ -29,6 +32,7 @@ impl From<RpcError> for ErrorObjectOwned {
             RpcError::Unsupported => unsupported(),
             RpcError::Web3Error(error) => into_jsrpc_error(error),
             RpcError::Other(error) => internal(error.to_string()),
+            RpcError::NodeError(error) => internal(error.to_string()),
         }
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -321,10 +321,9 @@ async fn start_program() -> Result<(), AnvilZksyncError> {
     // during replay. Otherwise, replay would send commands and hang.
     tokio::spawn(async move {
         if let Err(err) = node_executor.run().await {
-            let error = err.context("Node executor ended with error");
-            sh_err!("{:?}", error);
+            sh_err!("{err}");
 
-            let _ = telemetry.track_error(Box::new(error.as_ref())).await;
+            let _ = telemetry.track_error(Box::new(&err)).await;
         }
     });
 

--- a/crates/core/src/node/in_memory_ext.rs
+++ b/crates/core/src/node/in_memory_ext.rs
@@ -6,6 +6,7 @@ use anyhow::{anyhow, Context};
 use std::str::FromStr;
 use std::time::Duration;
 use url::Url;
+use zksync_error::anvil_zksync::node::AnvilNodeError;
 use zksync_types::api::{Block, TransactionVariant};
 use zksync_types::bytecode::BytecodeHash;
 use zksync_types::u256_to_h256;
@@ -55,7 +56,7 @@ impl InMemoryNode {
     ///
     /// # Returns
     /// The difference between the `current_timestamp` and the new timestamp for the InMemoryNodeInner.
-    pub async fn set_time(&self, timestamp: u64) -> Result<i128> {
+    pub async fn set_time(&self, timestamp: u64) -> std::result::Result<i128, AnvilNodeError> {
         self.node_handle.set_current_timestamp_sync(timestamp).await
     }
 

--- a/crates/core/src/node/inner/time.rs
+++ b/crates/core/src/node/inner/time.rs
@@ -1,5 +1,5 @@
-use anyhow::anyhow;
 use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
+use zksync_error::anvil_zksync::{self, node::AnvilNodeError};
 
 /// Read-only view on time.
 pub trait ReadTime: Send + Sync {
@@ -68,10 +68,10 @@ impl Time {
     /// before the next invocation of `advance_timestamp`.
     ///
     /// Expects provided timestamp to be in the future, returns error otherwise.
-    pub(super) fn enforce_next_timestamp(&self, timestamp: u64) -> anyhow::Result<()> {
+    pub(super) fn enforce_next_timestamp(&self, timestamp: u64) -> Result<(), AnvilNodeError> {
         let mut this = self.get_mut();
         if timestamp <= this.current_timestamp {
-            Err(anyhow!(
+            Err(anvil_zksync::node::generic_error!(
                 "timestamp ({}) must be greater than the last used timestamp ({})",
                 timestamp,
                 this.current_timestamp

--- a/crates/zksync_error/Cargo.toml
+++ b/crates/zksync_error/Cargo.toml
@@ -11,6 +11,7 @@ version.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+zksync_types.workspace = true
 lazy_static.workspace = true
 serde = { workspace = true, features = [ "rc" ] }
 serde_json.workspace = true

--- a/crates/zksync_error/resources/error-model-dump.json
+++ b/crates/zksync_error/resources/error-model-dump.json
@@ -55,6 +55,22 @@
           }
         }
       },
+      "AnvilNode": {
+        "name": "AnvilNode",
+        "meta": {
+          "description": ""
+        },
+        "bindings": {
+          "rust": {
+            "name": "Box<AnvilNode>",
+            "path": ""
+          },
+          "typescript": {
+            "name": "Box<AnvilNode>",
+            "path": ""
+          }
+        }
+      },
       "EraVM": {
         "name": "EraVM",
         "meta": {
@@ -115,6 +131,30 @@
           },
           "typescript": {
             "name": "Box<FoundryZksync>",
+            "path": ""
+          }
+        }
+      },
+      "H160": {
+        "name": "H160",
+        "meta": {
+          "description": "160-bit hash"
+        },
+        "bindings": {
+          "rust": {
+            "name": "H160",
+            "path": ""
+          }
+        }
+      },
+      "H256": {
+        "name": "H256",
+        "meta": {
+          "description": "256-bit hash"
+        },
+        "bindings": {
+          "rust": {
+            "name": "H256",
             "path": ""
           }
         }
@@ -263,6 +303,18 @@
           }
         }
       },
+      "U256": {
+        "name": "U256",
+        "meta": {
+          "description": "256-bit unsigned integer"
+        },
+        "bindings": {
+          "rust": {
+            "name": "U256",
+            "path": ""
+          }
+        }
+      },
       "WrappedError": {
         "name": "WrappedError",
         "meta": {
@@ -375,6 +427,7 @@
         "components": [
           "AnvilEnvironment",
           "AnvilGeneric",
+          "AnvilNode",
           "Halt",
           "Revert"
         ],
@@ -502,6 +555,20 @@
           "typescript": "AnvilGeneric"
         },
         "identifier": "gen",
+        "description": "",
+        "origins": [
+          "../../etc/errors/anvil.json"
+        ]
+      },
+      "AnvilNode": {
+        "name": "AnvilNode",
+        "code": 10,
+        "domain_name": "AnvilZKsync",
+        "bindings": {
+          "rust": "AnvilNode",
+          "typescript": "AnvilNode"
+        },
+        "identifier": "node",
         "description": "",
         "origins": [
           "../../etc/errors/anvil.json"
@@ -1927,6 +1994,228 @@
           },
           "typescript": {
             "name": "Unknown",
+            "path": ""
+          }
+        },
+        "origins": [
+          "../../etc/errors/anvil.json"
+        ]
+      },
+      "[anvil_zksync-node-0]": {
+        "domain": "AnvilZKsync",
+        "component": "AnvilNode",
+        "name": "GenericError",
+        "code": 0,
+        "identifier": "[anvil_zksync-node-0]",
+        "message": "Generic error: {message}",
+        "fields": [
+          {
+            "name": "message",
+            "type": "string"
+          }
+        ],
+        "documentation": null,
+        "bindings": {
+          "rust": {
+            "name": "GenericError",
+            "path": ""
+          },
+          "typescript": {
+            "name": "GenericError",
+            "path": ""
+          }
+        },
+        "origins": []
+      },
+      "[anvil_zksync-node-10]": {
+        "domain": "AnvilZKsync",
+        "component": "AnvilNode",
+        "name": "TransactionHalt",
+        "code": 10,
+        "identifier": "[anvil_zksync-node-10]",
+        "message": "",
+        "fields": [
+          {
+            "name": "inner",
+            "type": "Halt"
+          }
+        ],
+        "documentation": null,
+        "bindings": {
+          "rust": {
+            "name": "TransactionHalt",
+            "path": ""
+          },
+          "typescript": {
+            "name": "TransactionHalt",
+            "path": ""
+          }
+        },
+        "origins": [
+          "../../etc/errors/anvil.json"
+        ]
+      },
+      "[anvil_zksync-node-11]": {
+        "domain": "AnvilZKsync",
+        "component": "AnvilNode",
+        "name": "TransactionFailed",
+        "code": 11,
+        "identifier": "[anvil_zksync-node-11]",
+        "message": "",
+        "fields": [
+          {
+            "name": "failed_transactions_hashes",
+            "type": "string"
+          }
+        ],
+        "documentation": null,
+        "bindings": {
+          "rust": {
+            "name": "TransactionFailed",
+            "path": ""
+          },
+          "typescript": {
+            "name": "TransactionFailed",
+            "path": ""
+          }
+        },
+        "origins": [
+          "../../etc/errors/anvil.json"
+        ]
+      },
+      "[anvil_zksync-node-1]": {
+        "domain": "AnvilZKsync",
+        "component": "AnvilNode",
+        "name": "TransactionValidationFailedGasLimit",
+        "code": 1,
+        "identifier": "[anvil_zksync-node-1]",
+        "message": "",
+        "fields": [
+          {
+            "name": "transaction_hash",
+            "type": "H256"
+          },
+          {
+            "name": "tx_gas_limit",
+            "type": "U256"
+          },
+          {
+            "name": "tx_gas_per_pubdata_limit",
+            "type": "U256"
+          },
+          {
+            "name": "max_gas",
+            "type": "U256"
+          }
+        ],
+        "documentation": null,
+        "bindings": {
+          "rust": {
+            "name": "TransactionValidationFailedGasLimit",
+            "path": ""
+          },
+          "typescript": {
+            "name": "TransactionValidationFailedGasLimit",
+            "path": ""
+          }
+        },
+        "origins": [
+          "../../etc/errors/anvil.json"
+        ]
+      },
+      "[anvil_zksync-node-21]": {
+        "domain": "AnvilZKsync",
+        "component": "AnvilNode",
+        "name": "SealingBlockFailed",
+        "code": 21,
+        "identifier": "[anvil_zksync-node-21]",
+        "message": "",
+        "fields": [
+          {
+            "name": "block_transactions_hashes",
+            "type": "string"
+          }
+        ],
+        "documentation": null,
+        "bindings": {
+          "rust": {
+            "name": "SealingBlockFailed",
+            "path": ""
+          },
+          "typescript": {
+            "name": "SealingBlockFailed",
+            "path": ""
+          }
+        },
+        "origins": [
+          "../../etc/errors/anvil.json"
+        ]
+      },
+      "[anvil_zksync-node-2]": {
+        "domain": "AnvilZKsync",
+        "component": "AnvilNode",
+        "name": "TransactionValidationFailedMaxFeePerGasTooLow",
+        "code": 2,
+        "identifier": "[anvil_zksync-node-2]",
+        "message": "",
+        "fields": [
+          {
+            "name": "max_fee_per_gas",
+            "type": "U256"
+          },
+          {
+            "name": "transaction_hash",
+            "type": "H256"
+          },
+          {
+            "name": "l2_gas_price",
+            "type": "U256"
+          }
+        ],
+        "documentation": null,
+        "bindings": {
+          "rust": {
+            "name": "TransactionValidationFailedMaxFeePerGasTooLow",
+            "path": ""
+          },
+          "typescript": {
+            "name": "TransactionValidationFailedMaxFeePerGasTooLow",
+            "path": ""
+          }
+        },
+        "origins": [
+          "../../etc/errors/anvil.json"
+        ]
+      },
+      "[anvil_zksync-node-3]": {
+        "domain": "AnvilZKsync",
+        "component": "AnvilNode",
+        "name": "MaxPriorityFeeGreaterThanMaxFee",
+        "code": 3,
+        "identifier": "[anvil_zksync-node-3]",
+        "message": "",
+        "fields": [
+          {
+            "name": "max_fee_per_gas",
+            "type": "U256"
+          },
+          {
+            "name": "max_priority_fee_per_gas",
+            "type": "U256"
+          },
+          {
+            "name": "transaction_hash",
+            "type": "H256"
+          }
+        ],
+        "documentation": null,
+        "bindings": {
+          "rust": {
+            "name": "MaxPriorityFeeGreaterThanMaxFee",
+            "path": ""
+          },
+          "typescript": {
+            "name": "MaxPriorityFeeGreaterThanMaxFee",
             "path": ""
           }
         },

--- a/crates/zksync_error/src/error/domains.rs
+++ b/crates/zksync_error/src/error/domains.rs
@@ -7,6 +7,8 @@ use crate::error::definitions::AnvilEnvironment;
 use crate::error::definitions::AnvilEnvironmentCode;
 use crate::error::definitions::AnvilGeneric;
 use crate::error::definitions::AnvilGenericCode;
+use crate::error::definitions::AnvilNode;
+use crate::error::definitions::AnvilNodeCode;
 use crate::error::definitions::EraVM;
 use crate::error::definitions::EraVMCode;
 use crate::error::definitions::ExecutionPlatform;
@@ -96,6 +98,9 @@ impl ZksyncError {
             ZksyncError::AnvilZksync(AnvilZksync::AnvilGeneric(_)) => {
                 Kind::AnvilZksync(AnvilZksyncCode::AnvilGeneric)
             }
+            ZksyncError::AnvilZksync(AnvilZksync::AnvilNode(_)) => {
+                Kind::AnvilZksync(AnvilZksyncCode::AnvilNode)
+            }
             ZksyncError::AnvilZksync(AnvilZksync::Halt(_)) => {
                 Kind::AnvilZksync(AnvilZksyncCode::Halt)
             }
@@ -135,6 +140,9 @@ impl ZksyncError {
             }
             ZksyncError::AnvilZksync(AnvilZksync::AnvilGeneric(error)) => {
                 Into::<AnvilGenericCode>::into(error) as u32
+            }
+            ZksyncError::AnvilZksync(AnvilZksync::AnvilNode(error)) => {
+                Into::<AnvilNodeCode>::into(error) as u32
             }
             ZksyncError::AnvilZksync(AnvilZksync::Halt(error)) => {
                 Into::<HaltCode>::into(error) as u32
@@ -198,6 +206,7 @@ impl std::error::Error for ZksyncError {}
 pub enum AnvilZksync {
     AnvilEnvironment(AnvilEnvironment),
     AnvilGeneric(AnvilGeneric),
+    AnvilNode(AnvilNode),
     Halt(Halt),
     Revert(Revert),
 }
@@ -224,6 +233,16 @@ impl ICustomError<ZksyncError, ZksyncError> for AnvilGeneric {
 impl From<AnvilGeneric> for AnvilZksync {
     fn from(val: AnvilGeneric) -> Self {
         AnvilZksync::AnvilGeneric(val)
+    }
+}
+impl ICustomError<ZksyncError, ZksyncError> for AnvilNode {
+    fn to_unified(&self) -> ZksyncError {
+        AnvilZksync::AnvilNode(self.clone()).to_unified()
+    }
+}
+impl From<AnvilNode> for AnvilZksync {
+    fn from(val: AnvilNode) -> Self {
+        AnvilZksync::AnvilNode(val)
     }
 }
 impl ICustomError<ZksyncError, ZksyncError> for Halt {
@@ -264,6 +283,7 @@ impl crate::documentation::Documented for AnvilZksync {
         match self {
             AnvilZksync::AnvilEnvironment(error) => error.get_documentation(),
             AnvilZksync::AnvilGeneric(error) => error.get_documentation(),
+            AnvilZksync::AnvilNode(error) => error.get_documentation(),
             AnvilZksync::Halt(error) => error.get_documentation(),
             AnvilZksync::Revert(error) => error.get_documentation(),
         }
@@ -274,6 +294,7 @@ impl std::fmt::Display for AnvilZksync {
         match self {
             AnvilZksync::AnvilEnvironment(component) => component.fmt(f),
             AnvilZksync::AnvilGeneric(component) => component.fmt(f),
+            AnvilZksync::AnvilNode(component) => component.fmt(f),
             AnvilZksync::Halt(component) => component.fmt(f),
             AnvilZksync::Revert(component) => component.fmt(f),
         }

--- a/crates/zksync_error/src/error/mod.rs
+++ b/crates/zksync_error/src/error/mod.rs
@@ -49,6 +49,7 @@ impl IError<ZksyncError> for ZksyncError {
         match self {
             ZksyncError::AnvilZksync(AnvilZksync::AnvilEnvironment(error)) => error.get_message(),
             ZksyncError::AnvilZksync(AnvilZksync::AnvilGeneric(error)) => error.get_message(),
+            ZksyncError::AnvilZksync(AnvilZksync::AnvilNode(error)) => error.get_message(),
             ZksyncError::AnvilZksync(AnvilZksync::Halt(error)) => error.get_message(),
             ZksyncError::AnvilZksync(AnvilZksync::Revert(error)) => error.get_message(),
             ZksyncError::Compiler(Compiler::LLVM_EVM(error)) => error.get_message(),

--- a/crates/zksync_error/src/identifier.rs
+++ b/crates/zksync_error/src/identifier.rs
@@ -79,6 +79,7 @@ impl Identifying for Kind {
         match self {
             Kind::AnvilZksync(AnvilZksyncCode::AnvilEnvironment) => "anvil_zksync-env",
             Kind::AnvilZksync(AnvilZksyncCode::AnvilGeneric) => "anvil_zksync-gen",
+            Kind::AnvilZksync(AnvilZksyncCode::AnvilNode) => "anvil_zksync-node",
             Kind::AnvilZksync(AnvilZksyncCode::Halt) => "anvil_zksync-halt",
             Kind::AnvilZksync(AnvilZksyncCode::Revert) => "anvil_zksync-revert",
             Kind::Compiler(CompilerCode::LLVM_EVM) => "compiler-llvm+evm",
@@ -109,6 +110,11 @@ impl NamedError for Identifier {
             }
             Kind::AnvilZksync(AnvilZksyncCode::AnvilGeneric) => {
                 crate::error::definitions::AnvilGenericCode::from_repr(self.code)
+                    .expect("Internal error")
+                    .get_error_name()
+            }
+            Kind::AnvilZksync(AnvilZksyncCode::AnvilNode) => {
+                crate::error::definitions::AnvilNodeCode::from_repr(self.code)
                     .expect("Internal error")
                     .get_error_name()
             }

--- a/crates/zksync_error/src/lib.rs
+++ b/crates/zksync_error/src/lib.rs
@@ -62,6 +62,30 @@ pub mod anvil_zksync {
             })
         }
     }
+    pub mod node {
+        pub use crate::error::definitions::AnvilNode as AnvilNodeError;
+        pub use crate::error::definitions::AnvilNode::GenericError;
+        pub use crate::error::definitions::AnvilNode::MaxPriorityFeeGreaterThanMaxFee;
+        pub use crate::error::definitions::AnvilNode::SealingBlockFailed;
+        pub use crate::error::definitions::AnvilNode::TransactionFailed;
+        pub use crate::error::definitions::AnvilNode::TransactionHalt;
+        pub use crate::error::definitions::AnvilNode::TransactionValidationFailedGasLimit;
+        pub use crate::error::definitions::AnvilNode::TransactionValidationFailedMaxFeePerGasTooLow;
+        pub use crate::error::definitions::AnvilNodeCode as ErrorCode;
+        #[macro_export]
+        macro_rules ! anvil_zksync_node_generic_error { ($ ($ arg : tt) *) => { zksync_error :: anvil_zksync :: node :: AnvilNodeError :: GenericError { message : format ! ($ ($ arg) *) } } ; }
+        pub use crate::anvil_zksync_node_generic_error as generic_error;
+        pub fn to_generic<T: std::fmt::Display>(err: T) -> AnvilNodeError {
+            GenericError {
+                message: err.to_string(),
+            }
+        }
+        pub fn to_domain<T: std::fmt::Display>(err: T) -> super::AnvilZksyncError {
+            super::AnvilZksyncError::AnvilNode(GenericError {
+                message: err.to_string(),
+            })
+        }
+    }
     pub mod halt {
         pub use crate::error::definitions::Halt as HaltError;
         pub use crate::error::definitions::Halt::BootloaderOutOfGas;

--- a/etc/errors/anvil.json
+++ b/etc/errors/anvil.json
@@ -780,6 +780,109 @@
               }
             }
           ]
+        },
+        {
+          "component_name": "AnvilNode",
+          "component_code": 10,
+          "identifier_encoding": "node",
+          "errors" : [
+            {
+              "name": "TransactionValidationFailedGasLimit",
+              "code": 1,
+              "message": "",
+              "fields": [
+                {
+                  "name": "transaction_hash",
+                  "type": "H256"
+                },
+                {
+                  "name": "tx_gas_limit",
+                  "type": "U256"
+                },
+                {
+                  "name": "tx_gas_per_pubdata_limit",
+                  "type": "U256"
+                },
+                {
+                  "name": "max_gas",
+                  "type": "U256"
+                }
+              ]
+            },
+            {
+              "name": "TransactionValidationFailedMaxFeePerGasTooLow",
+              "code": 2,
+              "message": "",
+              "fields": [
+                {
+                  "name": "max_fee_per_gas",
+                  "type": "U256"
+                },
+                {
+                  "name": "transaction_hash",
+                  "type": "H256"
+                },
+                {
+                  "name": "l2_gas_price",
+                  "type": "U256"
+                }
+              ]
+            },
+            {
+              "name": "MaxPriorityFeeGreaterThanMaxFee",
+              "code": 3,
+              "message": "",
+              "fields": [
+                {
+                  "name": "max_fee_per_gas",
+                  "type": "U256"
+                },
+                {
+                  "name": "max_priority_fee_per_gas",
+                  "type": "U256"
+                },
+                {
+                  "name": "transaction_hash",
+                  "type": "H256"
+                }
+              ]
+            },
+            {
+              "name": "TransactionHalt",
+              "code": 10,
+              "message": "",
+              "fields": [
+                {
+                  "name": "inner",
+                  "type": "Halt"
+                }
+              ]
+            },
+            {
+              "name": "TransactionFailed",
+              "code": 11,
+              "message": "",
+              "fields": [
+                {
+                  "name": "failed_transactions_hashes",
+                  "type": "string"
+                }
+              ]
+            },
+            {
+              "name": "SealingBlockFailed",
+              "code": 21,
+              "message": "",
+              "fields": [
+                {
+                  "name": "block_transactions_hashes",
+                  "type": "string"
+                }
+              ]
+            }
+
+
+          ]
         }
       ]
     }


### PR DESCRIPTION
# What :computer: 
* update zksync-error version
* Migrate Node component errors to zksync-error

# Why :hand:
* Part of an effort to harmonize failure handling and reporting

# Evidence :camera: 

