### PR TITLE
chore: upgrade alloy to 0.12.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,19 +24,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
-name = "ahash"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
-dependencies = [
- "cfg-if",
- "getrandom 0.2.15",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,9 +40,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "0.9.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbcc41e8a11a4975b18ec6afba2cc48d591fa63336a4c526dacb50479a8d6b35"
+checksum = "89ec9b8795b2083585293bd3d19033e9d67e725917c95c44cb154e3400529ccd"
 dependencies = [
  "alloy-consensus",
  "alloy-core",
@@ -64,6 +51,7 @@ dependencies = [
  "alloy-provider",
  "alloy-rpc-client",
  "alloy-rpc-types",
+ "alloy-serde",
  "alloy-signer",
  "alloy-signer-aws",
  "alloy-signer-gcp",
@@ -81,14 +69,14 @@ checksum = "4ab9d1367c6ffb90c93fb4a9a4989530aa85112438c6f73a734067255d348469"
 dependencies = [
  "alloy-primitives",
  "num_enum 0.7.3",
- "strum",
+ "strum 0.26.3",
 ]
 
 [[package]]
 name = "alloy-consensus"
-version = "0.9.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4138dc275554afa6f18c4217262ac9388790b2fc393c2dfe03c51d357abf013"
+checksum = "a84efb7b8ddb9223346bfad9d8094e1a100c254037a3b5913243bfa8e04be266"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -97,15 +85,21 @@ dependencies = [
  "alloy-trie",
  "auto_impl",
  "c-kzg",
- "derive_more 1.0.0",
+ "derive_more 2.0.1",
+ "either",
+ "k256 0.13.4",
+ "once_cell",
+ "rand 0.8.5",
  "serde",
+ "serde_with 3.12.0",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "alloy-consensus-any"
-version = "0.9.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa04e1882c31288ce1028fdf31b6ea94cfa9eafa2e497f903ded631c8c6a42c"
+checksum = "fafded0c1ff8f0275c4a484239058e1c01c0c2589f8a16e03669ef7094a06f9b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -117,9 +111,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-core"
-version = "0.8.15"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c618bd382f0bc2ac26a7e4bfae01c9b015ca8f21b37ca40059ae35a7e62b3dc6"
+checksum = "ca1380cc3c81b83d5234865779494970c83b5893b423c59cdd68c3cd1ed0b671"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -129,20 +123,33 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "0.8.21"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555896f0b8578adb522b1453b6e6cc6704c3027bd0af20058befdde992cee8e9"
+checksum = "7078bef2bc353c1d1a97b44981d0186198be320038fbfbb0b37d1dd822a555d3"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
  "alloy-sol-type-parser",
  "alloy-sol-types",
  "const-hex",
- "derive_more 1.0.0",
+ "derive_more 2.0.1",
  "itoa",
  "serde",
  "serde_json",
  "winnow 0.7.2",
+]
+
+[[package]]
+name = "alloy-eip2124"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "675264c957689f0fd75f5993a73123c2cc3b5c235a38f5b9037fe6c826bfb2c0"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "crc",
+ "serde",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -158,29 +165,32 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7702"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cabf647eb4650c91a9d38cb6f972bb320009e7e9d61765fb688a86f1563b33e8"
+checksum = "9b15b13d38b366d01e818fe8e710d4d702ef7499eacd44926a06171dd9585d0c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "derive_more 1.0.0",
  "serde",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "alloy-eips"
-version = "0.9.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52dd5869ed09e399003e0e0ec6903d981b2a92e74c5d37e6b40890bad2517526"
+checksum = "5f4bffedaddc627520eabdcbfe27a2d2c2f716e15295e2ed1010df3feae67040"
 dependencies = [
+ "alloy-eip2124",
  "alloy-eip2930",
  "alloy-eip7702",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
+ "auto_impl",
  "c-kzg",
- "derive_more 1.0.0",
+ "derive_more 2.0.1",
+ "either",
  "once_cell",
  "serde",
  "sha2",
@@ -188,9 +198,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "0.8.21"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4012581681b186ba0882007ed873987cc37f86b1b488fe6b91d5efd0b585dc41"
+checksum = "ec80745c33797e8baf547a8cfeb850e60d837fe9b9e67b3f579c1fcd26f527e9"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -200,9 +210,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "0.9.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2008bedb8159a255b46b7c8614516eda06679ea82f620913679afbd8031fea72"
+checksum = "6929e607b0a56803c69c68adc6e8aae1644c94e37ea458aa2d0713fc77490e70"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -214,9 +224,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "0.9.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4556f01fe41d0677495df10a648ddcf7ce118b0e8aa9642a0e2b6dd1fb7259de"
+checksum = "c2b14524c3605ed5ee173b966333089474415416a8cfd80ceb003c18fd6d1736"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -231,6 +241,7 @@ dependencies = [
  "alloy-sol-types",
  "async-trait",
  "auto_impl",
+ "derive_more 2.0.1",
  "futures-utils-wasm",
  "serde",
  "serde_json",
@@ -239,9 +250,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "0.9.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31c3c6b71340a1d076831823f09cb6e02de01de5c6630a9631bdb36f947ff80"
+checksum = "4c06932646544ea341f0fda48d2c0fe4fda75bc132379cb84019cdfb6ddcb0fb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -252,15 +263,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.8.21"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478bedf4d24e71ea48428d1bc278553bd7c6ae07c30ca063beb0b09fe58a9e74"
+checksum = "eacedba97e65cdc7ab592f2b22ef5d3ab8d60b2056bc3a6e6363577e8270ec6f"
 dependencies = [
  "alloy-rlp",
  "bytes",
  "cfg-if",
  "const-hex",
- "derive_more 1.0.0",
+ "derive_more 2.0.1",
  "foldhash",
  "hashbrown 0.15.2",
  "indexmap 2.6.0",
@@ -279,9 +290,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "0.9.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22c4441b3ebe2d77fa9cf629ba68c3f713eb91779cff84275393db97eddd82"
+checksum = "ff1ec2eabd9b3acc46e59247c35f75545960372431c68f7fdbfcfb970a486c30"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -293,6 +304,7 @@ dependencies = [
  "alloy-rpc-client",
  "alloy-rpc-types-anvil",
  "alloy-rpc-types-eth",
+ "alloy-sol-types",
  "alloy-transport",
  "alloy-transport-http",
  "async-stream",
@@ -305,7 +317,6 @@ dependencies = [
  "parking_lot",
  "pin-project 1.1.7",
  "reqwest 0.12.12",
- "schnellru",
  "serde",
  "serde_json",
  "thiserror 2.0.11",
@@ -339,9 +350,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "0.9.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d06a292b37e182e514903ede6e623b9de96420e8109ce300da288a96d88b7e4b"
+checksum = "6213829d8eabc239c2f9572452a5993ebdf78b04c020abc450ae48c54261d4ce"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -362,9 +373,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "0.9.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9383845dd924939e7ab0298bbfe231505e20928907d7905aa3bf112287305e06"
+checksum = "a153db94cf231b03238fe4da48f59dc6f36e01b5e4d5a2e30de33b95395380fa"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-anvil",
@@ -376,9 +387,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "0.9.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11495cb8c8d3141fc27556a4c9188b81531ad5ec3076a0394c61a6dcfbce9f34"
+checksum = "5462937f088889c337c236c2509226e87a26301d2b01f9fafee246bd84cb0407"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -388,9 +399,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "0.9.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca445cef0eb6c2cf51cfb4e214fbf1ebd00893ae2e6f3b944c8101b07990f988"
+checksum = "2cd4ceea38ea27eeb26f021df34ed5b7b793704ad7a2a009f16137a19461e7ca"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -399,25 +410,26 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "0.9.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f821f30344862a0b6eb9a1c2eb91dfb2ff44c7489f37152a526cdcab79264"
+checksum = "b1a1a0710dbfbab2b33200ef45c650963d63edf6a81b2c7399ede762b3586dfd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
- "derive_more 1.0.0",
+ "derive_more 2.0.1",
+ "rand 0.8.5",
  "serde",
- "strum",
+ "strum 0.27.1",
 ]
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "0.9.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0938bc615c02421bd86c1733ca7205cc3d99a122d9f9bff05726bd604b76a5c2"
+checksum = "8e18d94b1036302720b987564560e4a5b85035a17553c53a50afa2bd8762b487"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -435,9 +447,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "0.9.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae0465c71d4dced7525f408d84873aeebb71faf807d22d74c4a426430ccd9b55"
+checksum = "9824e1bf92cd7848ca6fabb01c9aca15c9c5fb0ab96da5514ef0543f021c69f6"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -446,15 +458,16 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "0.9.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bfa395ad5cc952c82358d31e4c68b27bf4a89a5456d9b27e226e77dac50e4ff"
+checksum = "81755ed6a6a33061302ac95e9bb7b40ebf7078e4568397168024242bc31a3e58"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
  "alloy-sol-types",
  "async-trait",
  "auto_impl",
+ "either",
  "elliptic-curve 0.13.8",
  "k256 0.13.4",
  "thiserror 2.0.11",
@@ -462,9 +475,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-aws"
-version = "0.9.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eb06810c34427d499863817eb506acf57cb9ded9224b374116cae4e22dbd4e9"
+checksum = "3c4861024ab627a150e07d2658ae29bb90d27cd1caddc2f6deff5b940167508b"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -480,9 +493,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-gcp"
-version = "0.9.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d629e63fec8802ad53706d46e8eceeeae2b135c6648d0de41669a523bf17df4a"
+checksum = "4265500541723b09b625e37d19b718bf13c0535830692c5cf176619e2df678f4"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -498,9 +511,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-ledger"
-version = "0.9.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b426789566a19252cb46b757d91543a6f8e70330c72f312b86c5878595d092ef"
+checksum = "3cb71c0a180015f377b74aed8bafa60c8967529a0b09f55212913ad012e57bd1"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -518,9 +531,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "0.9.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbdc63ce9eda1283fcbaca66ba4a414b841c0e3edbeef9c86a71242fc9e84ccc"
+checksum = "aa857621a5c95c13e640e18bb9c4720f4338a666d6276f55446477a6bc3912ff"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -536,9 +549,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "0.8.21"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2708e27f58d747423ae21d31b7a6625159bd8d867470ddd0256f396a68efa11"
+checksum = "3637022e781bc73a9e300689cd91105a0e6be00391dd4e2110a71cc7e9f20a94"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -550,9 +563,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "0.8.21"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6b7984d7e085dec382d2c5ef022b533fcdb1fe6129200af30ebf5afddb6a361"
+checksum = "3b9bd22d0bba90e40f40c625c33d39afb7d62b22192476a2ce1dcf8409dce880"
 dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input",
@@ -569,14 +582,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "0.8.21"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d6a9fc4ed1a3c70bdb2357bec3924551c1a59f24e5a04a74472c755b37f87d"
+checksum = "05ae4646e8123ec2fd10f9c22e361ffe4365c42811431829c2eabae528546bcc"
 dependencies = [
  "alloy-json-abi",
  "const-hex",
  "dunce",
  "heck",
+ "macro-string",
  "proc-macro2",
  "quote",
  "serde_json",
@@ -586,9 +600,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "0.8.21"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1b3e9a48a6dd7bb052a111c8d93b5afc7956ed5e2cb4177793dc63bb1d2a36"
+checksum = "488a747fdcefeec5c1ed5aa9e08becd775106777fdeae2a35730729fc8a95910"
 dependencies = [
  "serde",
  "winnow 0.7.2",
@@ -596,9 +610,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "0.8.21"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6044800da35c38118fd4b98e18306bd3b91af5dedeb54c1b768cf1b4fb68f549"
+checksum = "767957235807b021126dca1598ac3ef477007eace07961607dc5f490550909c7"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -609,13 +623,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "0.9.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d17722a198f33bbd25337660787aea8b8f57814febb7c746bc30407bdfc39448"
+checksum = "6c74598eb65cefa886be6ba624c14a6856d9d84339ec720520f3efcc03311716"
 dependencies = [
  "alloy-json-rpc",
  "base64 0.22.1",
- "futures-util",
  "futures-utils-wasm",
  "serde",
  "serde_json",
@@ -629,9 +642,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "0.9.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1509599021330a31c4a6816b655e34bf67acb1cc03c564e09fd8754ff6c5de"
+checksum = "cfcd2f8ab2f053cd848ead5d625cb1b63716562951101588c1fa49300e3c6418"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -743,7 +756,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
- "serde_with",
+ "serde_with 1.14.0",
  "tempfile",
  "tokio",
  "tower 0.4.13",
@@ -879,7 +892,7 @@ dependencies = [
  "semver 1.0.26",
  "serde",
  "serde_json",
- "serde_with",
+ "serde_with 1.14.0",
  "serde_yaml",
  "tempfile",
  "tokio",
@@ -2019,6 +2032,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2255,6 +2283,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+ "serde",
 ]
 
 [[package]]
@@ -2440,15 +2469,19 @@ dependencies = [
  "digest 0.10.7",
  "elliptic-curve 0.13.8",
  "rfc6979 0.4.0",
+ "serdect",
  "signature 2.2.0",
  "spki 0.7.3",
 ]
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "elliptic-curve"
@@ -2486,6 +2519,7 @@ dependencies = [
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "sec1 0.7.3",
+ "serdect",
  "subtle",
  "zeroize",
 ]
@@ -2812,9 +2846,9 @@ checksum = "42012b0f064e01aa58b545fe3727f90f7dd4020f4a3ea735b50344965f5a57e9"
 
 [[package]]
 name = "gcloud-sdk"
-version = "0.25.8"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0775bfa745cdf7287ae9765a685a813b91049b6b6d5ca3de20a3d5d16a80d8b2"
+checksum = "a6392faf01950e198a204b13034efd7aadda1877e7c174f5442ee39bad5d99bd"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3044,12 +3078,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 
 [[package]]
 name = "hashbrown"
@@ -3587,6 +3615,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -3891,6 +3920,7 @@ dependencies = [
  "ecdsa 0.16.9",
  "elliptic-curve 0.13.8",
  "once_cell",
+ "serdect",
  "sha2",
  "signature 2.2.0",
 ]
@@ -4000,11 +4030,22 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
 dependencies = [
  "hashbrown 0.15.2",
+]
+
+[[package]]
+name = "macro-string"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -4275,7 +4316,9 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8983bb634df7248924ee0c4c3a749609b5abcb082c28fffe3254b3eb3602b307"
 dependencies = [
+ "alloy-rlp",
  "const-hex",
+ "proptest",
  "serde",
  "smallvec",
 ]
@@ -5511,17 +5554,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schnellru"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "356285bbf17bea63d9e52e96bd18f039672ac92b55b8cb997d6162a2a37d1649"
-dependencies = [
- "ahash",
- "cfg-if",
- "hashbrown 0.13.2",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5561,6 +5593,7 @@ dependencies = [
  "der 0.7.9",
  "generic-array",
  "pkcs8 0.10.2",
+ "serdect",
  "subtle",
  "zeroize",
 ]
@@ -5802,7 +5835,25 @@ checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
 dependencies = [
  "hex",
  "serde",
- "serde_with_macros",
+ "serde_with_macros 1.5.2",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.6.0",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with_macros 3.12.0",
+ "time",
 ]
 
 [[package]]
@@ -5818,6 +5869,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with_macros"
+version = "3.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
+dependencies = [
+ "darling 0.20.10",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5828,6 +5891,16 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "serdect"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+dependencies = [
+ "base16ct 0.2.0",
+ "serde",
 ]
 
 [[package]]
@@ -6059,7 +6132,16 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
+dependencies = [
+ "strum_macros 0.27.1",
 ]
 
 [[package]]
@@ -6067,6 +6149,19 @@ name = "strum_macros"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -6105,9 +6200,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "0.8.21"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c2de690018098e367beeb793991c7d4dc7270f42c9d2ac4ccc876c1368ca430"
+checksum = "d975606bae72d8aad5b07d9342465e123a2cccf53a5a735aedf81ca92a709ecb"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -7703,8 +7798,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_json_path_to_error",
- "strum",
- "strum_macros",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
  "syn 2.0.98",
  "tera",
  "thiserror 1.0.69",
@@ -7750,9 +7845,9 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
- "serde_with",
+ "serde_with 1.14.0",
  "sha2",
- "strum",
+ "strum 0.26.3",
  "thiserror 1.0.69",
  "tiny-keccak 2.0.2",
  "url",
@@ -7866,8 +7961,8 @@ dependencies = [
  "lazy_static",
  "serde",
  "serde_json",
- "strum",
- "strum_macros",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
  "zksync-error-description",
 ]
 
@@ -7991,7 +8086,7 @@ dependencies = [
  "rlp",
  "serde",
  "serde_json",
- "serde_with",
+ "serde_with 1.14.0",
  "thiserror 1.0.69",
  "tracing",
  "zksync_basic_types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ zksync-error-description = { git = "https://github.com/matter-labs/zksync-error"
 # External dependencies #
 #########################
 anyhow = "1.0"
-alloy = { version = "0.9.2", default-features = false }
+alloy = { version = "0.12.5", default-features = false }
 async-trait = "0.1.85"
 chrono = { version = "0.4.31", default-features = false }
 clap = { version = "4.2.4", features = ["derive", "env"] }

--- a/crates/l1_sidecar/src/anvil.rs
+++ b/crates/l1_sidecar/src/anvil.rs
@@ -120,7 +120,7 @@ pub async fn external(
 
     // Submit a transaction with very high gas to refresh anvil's fee estimator. Seems like some
     // >=1.0.0 versions are still affected by this bug.
-    let fees = provider.estimate_eip1559_fees(None).await?;
+    let fees = provider.estimate_eip1559_fees().await?;
     provider
         .send_transaction(
             TransactionRequest::default()
@@ -157,9 +157,8 @@ async fn setup_provider(address: &str, config: &ZkstackConfig) -> anyhow::Result
     let blob_operator_wallet =
         EthereumWallet::from(config.wallets.blob_operator.private_key.clone());
     let provider = ProviderBuilder::new()
-        .with_recommended_fillers()
         .wallet(blob_operator_wallet)
-        .on_builtin(address)
+        .connect(address)
         .await?;
 
     // Wait for anvil to be up

--- a/crates/l1_sidecar/src/l1_sender.rs
+++ b/crates/l1_sidecar/src/l1_sender.rs
@@ -105,7 +105,7 @@ impl L1Sender {
         );
 
         let gas_price = self.provider.get_gas_price().await?;
-        let eip1559_est = self.provider.estimate_eip1559_fees(None).await?;
+        let eip1559_est = self.provider.estimate_eip1559_fees().await?;
         let tx = TransactionRequest::default()
             .with_to(self.validator_timelock_addr.0.into())
             .with_max_fee_per_blob_gas(gas_price)
@@ -184,7 +184,7 @@ impl L1Sender {
         );
 
         let gas_price = self.provider.get_gas_price().await?;
-        let eip1559_est = self.provider.estimate_eip1559_fees(None).await?;
+        let eip1559_est = self.provider.estimate_eip1559_fees().await?;
         let tx = TransactionRequest::default()
             .with_to(self.validator_timelock_addr.0.into())
             .with_max_fee_per_blob_gas(gas_price)
@@ -265,7 +265,7 @@ impl L1Sender {
         );
 
         let gas_price = self.provider.get_gas_price().await?;
-        let eip1559_est = self.provider.estimate_eip1559_fees(None).await?;
+        let eip1559_est = self.provider.estimate_eip1559_fees().await?;
         let tx = TransactionRequest::default()
             .with_to(self.validator_timelock_addr.0.into())
             .with_max_fee_per_blob_gas(gas_price)

--- a/crates/l1_sidecar/src/l1_watcher.rs
+++ b/crates/l1_sidecar/src/l1_watcher.rs
@@ -2,7 +2,7 @@ use crate::contracts::NewPriorityRequest;
 use crate::zkstack_config::ZkstackConfig;
 use alloy::eips::BlockId;
 use alloy::providers::Provider;
-use alloy::rpc::types::{BlockTransactionsKind, Filter};
+use alloy::rpc::types::Filter;
 use alloy::sol_types::SolEvent;
 use anvil_zksync_core::node::TxPool;
 use anyhow::Context;
@@ -63,7 +63,7 @@ impl L1Watcher {
     async fn poll(&mut self) -> anyhow::Result<()> {
         let latest_block = self
             .provider
-            .get_block(BlockId::latest(), BlockTransactionsKind::Hashes)
+            .get_block(BlockId::latest())
             .await?
             .context("L1 does not have any block")?;
         let to_block = latest_block.header.number;

--- a/e2e-tests-rust/Cargo.lock
+++ b/e2e-tests-rust/Cargo.lock
@@ -18,19 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
-name = "ahash"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
-dependencies = [
- "cfg-if",
- "getrandom 0.2.15",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,9 +34,9 @@ checksum = "45862d1c77f2228b9e10bc609d5bc203d86ebc9b87ad8d5d5167a6c9abf739d9"
 
 [[package]]
 name = "alloy"
-version = "0.9.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbcc41e8a11a4975b18ec6afba2cc48d591fa63336a4c526dacb50479a8d6b35"
+checksum = "89ec9b8795b2083585293bd3d19033e9d67e725917c95c44cb154e3400529ccd"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -83,14 +70,14 @@ checksum = "18c5c520273946ecf715c0010b4e3503d7eba9893cd9ce6b7fff5654c4a3c470"
 dependencies = [
  "alloy-primitives",
  "num_enum 0.7.3",
- "strum",
+ "strum 0.26.3",
 ]
 
 [[package]]
 name = "alloy-consensus"
-version = "0.9.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4138dc275554afa6f18c4217262ac9388790b2fc393c2dfe03c51d357abf013"
+checksum = "a84efb7b8ddb9223346bfad9d8094e1a100c254037a3b5913243bfa8e04be266"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -99,16 +86,21 @@ dependencies = [
  "alloy-trie",
  "auto_impl",
  "c-kzg",
- "derive_more 1.0.0",
+ "derive_more 2.0.1",
+ "either",
  "k256 0.13.4",
+ "once_cell",
+ "rand 0.8.5",
  "serde",
+ "serde_with 3.12.0",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "alloy-consensus-any"
-version = "0.9.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa04e1882c31288ce1028fdf31b6ea94cfa9eafa2e497f903ded631c8c6a42c"
+checksum = "fafded0c1ff8f0275c4a484239058e1c01c0c2589f8a16e03669ef7094a06f9b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -120,10 +112,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "0.9.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f21886c1fea0626f755a49b2ac653b396fb345233f6170db2da3d0ada31560c"
+checksum = "7a0fa0584d13dd0c4e79288d411222c4d7c3411c71b7fa637cefda9dcf9bb1f9"
 dependencies = [
+ "alloy-consensus",
  "alloy-dyn-abi",
  "alloy-json-abi",
  "alloy-network",
@@ -141,9 +134,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-core"
-version = "0.8.15"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c618bd382f0bc2ac26a7e4bfae01c9b015ca8f21b37ca40059ae35a7e62b3dc6"
+checksum = "ca1380cc3c81b83d5234865779494970c83b5893b423c59cdd68c3cd1ed0b671"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -154,20 +147,33 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "0.8.15"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41056bde53ae10ffbbf11618efbe1e0290859e5eab0fe9ef82ebdb62f12a866f"
+checksum = "7078bef2bc353c1d1a97b44981d0186198be320038fbfbb0b37d1dd822a555d3"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
  "alloy-sol-type-parser",
  "alloy-sol-types",
  "const-hex",
- "derive_more 1.0.0",
+ "derive_more 2.0.1",
  "itoa",
  "serde",
  "serde_json",
- "winnow 0.6.20",
+ "winnow 0.7.4",
+]
+
+[[package]]
+name = "alloy-eip2124"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "675264c957689f0fd75f5993a73123c2cc3b5c235a38f5b9037fe6c826bfb2c0"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "crc",
+ "serde",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -183,30 +189,33 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7702"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cabf647eb4650c91a9d38cb6f972bb320009e7e9d61765fb688a86f1563b33e8"
+checksum = "9b15b13d38b366d01e818fe8e710d4d702ef7499eacd44926a06171dd9585d0c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "derive_more 1.0.0",
  "k256 0.13.4",
  "serde",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "alloy-eips"
-version = "0.9.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52dd5869ed09e399003e0e0ec6903d981b2a92e74c5d37e6b40890bad2517526"
+checksum = "5f4bffedaddc627520eabdcbfe27a2d2c2f716e15295e2ed1010df3feae67040"
 dependencies = [
+ "alloy-eip2124",
  "alloy-eip2930",
  "alloy-eip7702",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
+ "auto_impl",
  "c-kzg",
- "derive_more 1.0.0",
+ "derive_more 2.0.1",
+ "either",
  "once_cell",
  "serde",
  "sha2",
@@ -214,9 +223,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "0.9.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7d2a7fe5c1a9bd6793829ea21a636f30fc2b3f5d2e7418ba86d96e41dd1f460"
+checksum = "96b11774716152a5204aff0e86a8c841df499ea81464e2b1f82b3f72d6a2ef32"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -227,9 +236,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "0.8.15"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c357da577dfb56998d01f574d81ad7a1958d248740a7981b205d69d65a7da404"
+checksum = "ec80745c33797e8baf547a8cfeb850e60d837fe9b9e67b3f579c1fcd26f527e9"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -239,9 +248,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "0.9.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2008bedb8159a255b46b7c8614516eda06679ea82f620913679afbd8031fea72"
+checksum = "6929e607b0a56803c69c68adc6e8aae1644c94e37ea458aa2d0713fc77490e70"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -253,9 +262,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "0.9.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4556f01fe41d0677495df10a648ddcf7ce118b0e8aa9642a0e2b6dd1fb7259de"
+checksum = "c2b14524c3605ed5ee173b966333089474415416a8cfd80ceb003c18fd6d1736"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -270,6 +279,7 @@ dependencies = [
  "alloy-sol-types",
  "async-trait",
  "auto_impl",
+ "derive_more 2.0.1",
  "futures-utils-wasm",
  "serde",
  "serde_json",
@@ -278,9 +288,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "0.9.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31c3c6b71340a1d076831823f09cb6e02de01de5c6630a9631bdb36f947ff80"
+checksum = "4c06932646544ea341f0fda48d2c0fe4fda75bc132379cb84019cdfb6ddcb0fb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -291,12 +301,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-node-bindings"
-version = "0.9.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4520cd4bc5cec20c32c98e4bc38914c7fb96bf4a712105e44da186a54e65e3ba"
+checksum = "cb8702df5255ed061ccb452511328edf267ff8b1c356623e8f93a5b708d57273"
 dependencies = [
  "alloy-genesis",
+ "alloy-network",
  "alloy-primitives",
+ "alloy-signer",
+ "alloy-signer-local",
  "k256 0.13.4",
  "rand 0.8.5",
  "serde_json",
@@ -308,19 +321,18 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.8.15"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6259a506ab13e1d658796c31e6e39d2e2ee89243bcc505ddc613b35732e0a430"
+checksum = "eacedba97e65cdc7ab592f2b22ef5d3ab8d60b2056bc3a6e6363577e8270ec6f"
 dependencies = [
  "alloy-rlp",
  "bytes",
  "cfg-if",
  "const-hex",
- "derive_more 1.0.0",
+ "derive_more 2.0.1",
  "foldhash",
  "getrandom 0.2.15",
  "hashbrown 0.15.2",
- "hex-literal",
  "indexmap 2.6.0",
  "itoa",
  "k256 0.13.4",
@@ -329,7 +341,7 @@ dependencies = [
  "proptest",
  "rand 0.8.5",
  "ruint",
- "rustc-hash 2.0.0",
+ "rustc-hash 2.1.1",
  "serde",
  "sha3",
  "tiny-keccak 2.0.2",
@@ -337,9 +349,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "0.9.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22c4441b3ebe2d77fa9cf629ba68c3f713eb91779cff84275393db97eddd82"
+checksum = "ff1ec2eabd9b3acc46e59247c35f75545960372431c68f7fdbfcfb970a486c30"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -352,9 +364,11 @@ dependencies = [
  "alloy-pubsub",
  "alloy-rpc-client",
  "alloy-rpc-types-anvil",
+ "alloy-rpc-types-debug",
  "alloy-rpc-types-eth",
- "alloy-signer",
- "alloy-signer-local",
+ "alloy-rpc-types-trace",
+ "alloy-rpc-types-txpool",
+ "alloy-sol-types",
  "alloy-transport",
  "alloy-transport-http",
  "alloy-transport-ipc",
@@ -369,7 +383,6 @@ dependencies = [
  "parking_lot",
  "pin-project 1.1.7",
  "reqwest",
- "schnellru",
  "serde",
  "serde_json",
  "thiserror 2.0.11",
@@ -381,9 +394,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "0.9.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2269fd635f7b505f27c63a3cb293148cd02301efce4c8bdd9ff54fbfc4a20e23"
+checksum = "b1cf194abddb88b034d22ab41449ed8532e5113e58699cd055bf21d98a0991ab"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -422,9 +435,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "0.9.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d06a292b37e182e514903ede6e623b9de96420e8109ce300da288a96d88b7e4b"
+checksum = "6213829d8eabc239c2f9572452a5993ebdf78b04c020abc450ae48c54261d4ce"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -448,23 +461,25 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "0.9.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9383845dd924939e7ab0298bbfe231505e20928907d7905aa3bf112287305e06"
+checksum = "a153db94cf231b03238fe4da48f59dc6f36e01b5e4d5a2e30de33b95395380fa"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-anvil",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
+ "alloy-rpc-types-trace",
+ "alloy-rpc-types-txpool",
  "alloy-serde",
  "serde",
 ]
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "0.9.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11495cb8c8d3141fc27556a4c9188b81531ad5ec3076a0394c61a6dcfbce9f34"
+checksum = "5462937f088889c337c236c2509226e87a26301d2b01f9fafee246bd84cb0407"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -474,9 +489,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "0.9.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca445cef0eb6c2cf51cfb4e214fbf1ebd00893ae2e6f3b944c8101b07990f988"
+checksum = "2cd4ceea38ea27eeb26f021df34ed5b7b793704ad7a2a009f16137a19461e7ca"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -484,26 +499,37 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-rpc-types-engine"
-version = "0.9.2"
+name = "alloy-rpc-types-debug"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f821f30344862a0b6eb9a1c2eb91dfb2ff44c7489f37152a526cdcab79264"
+checksum = "8fa8f6e27d47b4c56c627cb03dc91624c26bd814f6609bb1d1a836148b76fc9b"
+dependencies = [
+ "alloy-primitives",
+ "serde",
+]
+
+[[package]]
+name = "alloy-rpc-types-engine"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1a1a0710dbfbab2b33200ef45c650963d63edf6a81b2c7399ede762b3586dfd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
- "derive_more 1.0.0",
+ "derive_more 2.0.1",
+ "rand 0.8.5",
  "serde",
- "strum",
+ "strum 0.27.1",
 ]
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "0.9.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0938bc615c02421bd86c1733ca7205cc3d99a122d9f9bff05726bd604b76a5c2"
+checksum = "8e18d94b1036302720b987564560e4a5b85035a17553c53a50afa2bd8762b487"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -520,10 +546,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-serde"
-version = "0.9.2"
+name = "alloy-rpc-types-trace"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae0465c71d4dced7525f408d84873aeebb71faf807d22d74c4a426430ccd9b55"
+checksum = "5ef4bba67ec601730ceb23e542980d73ae9f718819604dfdd8289b13a506e762"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.11",
+]
+
+[[package]]
+name = "alloy-rpc-types-txpool"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8edc8512f919feb79dd30864ef7574d2877e71b73e30b5de4925ba9bc6bd4f96"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "serde",
+]
+
+[[package]]
+name = "alloy-serde"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9824e1bf92cd7848ca6fabb01c9aca15c9c5fb0ab96da5514ef0543f021c69f6"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -532,15 +584,16 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "0.9.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bfa395ad5cc952c82358d31e4c68b27bf4a89a5456d9b27e226e77dac50e4ff"
+checksum = "81755ed6a6a33061302ac95e9bb7b40ebf7078e4568397168024242bc31a3e58"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
  "alloy-sol-types",
  "async-trait",
  "auto_impl",
+ "either",
  "elliptic-curve 0.13.8",
  "k256 0.13.4",
  "thiserror 2.0.11",
@@ -548,9 +601,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-aws"
-version = "0.9.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eb06810c34427d499863817eb506acf57cb9ded9224b374116cae4e22dbd4e9"
+checksum = "3c4861024ab627a150e07d2658ae29bb90d27cd1caddc2f6deff5b940167508b"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -566,9 +619,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-gcp"
-version = "0.9.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d629e63fec8802ad53706d46e8eceeeae2b135c6648d0de41669a523bf17df4a"
+checksum = "4265500541723b09b625e37d19b718bf13c0535830692c5cf176619e2df678f4"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -584,9 +637,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-ledger"
-version = "0.9.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b426789566a19252cb46b757d91543a6f8e70330c72f312b86c5878595d092ef"
+checksum = "3cb71c0a180015f377b74aed8bafa60c8967529a0b09f55212913ad012e57bd1"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -604,9 +657,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "0.9.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbdc63ce9eda1283fcbaca66ba4a414b841c0e3edbeef9c86a71242fc9e84ccc"
+checksum = "aa857621a5c95c13e640e18bb9c4720f4338a666d6276f55446477a6bc3912ff"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -622,9 +675,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "0.8.15"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9d64f851d95619233f74b310f12bcf16e0cbc27ee3762b6115c14a84809280a"
+checksum = "3637022e781bc73a9e300689cd91105a0e6be00391dd4e2110a71cc7e9f20a94"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -636,9 +689,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "0.8.15"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bf7ed1574b699f48bf17caab4e6e54c6d12bc3c006ab33d58b1e227c1c3559f"
+checksum = "3b9bd22d0bba90e40f40c625c33d39afb7d62b22192476a2ce1dcf8409dce880"
 dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input",
@@ -655,14 +708,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "0.8.15"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c02997ccef5f34f9c099277d4145f183b422938ed5322dc57a089fe9b9ad9ee"
+checksum = "05ae4646e8123ec2fd10f9c22e361ffe4365c42811431829c2eabae528546bcc"
 dependencies = [
  "alloy-json-abi",
  "const-hex",
  "dunce",
  "heck",
+ "macro-string",
  "proc-macro2",
  "quote",
  "serde_json",
@@ -672,19 +726,19 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "0.8.15"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce13ff37285b0870d0a0746992a4ae48efaf34b766ae4c2640fa15e5305f8e73"
+checksum = "488a747fdcefeec5c1ed5aa9e08becd775106777fdeae2a35730729fc8a95910"
 dependencies = [
  "serde",
- "winnow 0.6.20",
+ "winnow 0.7.4",
 ]
 
 [[package]]
 name = "alloy-sol-types"
-version = "0.8.15"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1174cafd6c6d810711b4e00383037bdb458efc4fe3dbafafa16567e0320c54d8"
+checksum = "767957235807b021126dca1598ac3ef477007eace07961607dc5f490550909c7"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -695,13 +749,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "0.9.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d17722a198f33bbd25337660787aea8b8f57814febb7c746bc30407bdfc39448"
+checksum = "6c74598eb65cefa886be6ba624c14a6856d9d84339ec720520f3efcc03311716"
 dependencies = [
  "alloy-json-rpc",
  "base64 0.22.1",
- "futures-util",
  "futures-utils-wasm",
  "serde",
  "serde_json",
@@ -715,9 +768,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "0.9.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1509599021330a31c4a6816b655e34bf67acb1cc03c564e09fd8754ff6c5de"
+checksum = "cfcd2f8ab2f053cd848ead5d625cb1b63716562951101588c1fa49300e3c6418"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -730,9 +783,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "0.9.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4da44bc9a5155ab599666d26decafcf12204b72a80eeaba7c5e234ee8ac205"
+checksum = "e61e2b5cbf16f7588e4420848b61824f6514944773732534f4129ba6a251e059"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -741,6 +794,7 @@ dependencies = [
  "futures 0.3.31",
  "interprocess",
  "pin-project 1.1.7",
+ "serde",
  "serde_json",
  "tokio",
  "tokio-util",
@@ -749,9 +803,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "0.9.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58011745b2f17b334db40df9077d75b181f78360a5bc5c35519e15d4bfce15e2"
+checksum = "67ddcf4b98b3448eb998e057dc5a27345997863d6544ee7f0f79957616768dd3"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -783,18 +837,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-zksync"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e9432f4705b656b59f2a84001a57b946510b3c1a01d38f2940fa1c4123b0b9a"
+version = "0.12.1"
 dependencies = [
  "alloy",
- "alloy-consensus-any",
  "async-trait",
  "chrono",
- "futures-utils-wasm",
  "k256 0.13.4",
- "rand 0.8.5",
- "reqwest",
+ "rand 0.9.0",
  "serde",
  "thiserror 2.0.11",
  "tracing",
@@ -1690,9 +1739,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.8.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 dependencies = [
  "serde",
 ]
@@ -2089,6 +2138,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2209,8 +2273,18 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.13.4",
+ "darling_macro 0.13.4",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core 0.20.10",
+ "darling_macro 0.20.10",
 ]
 
 [[package]]
@@ -2228,14 +2302,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
- "darling_core",
+ "darling_core 0.13.4",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core 0.20.10",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2286,6 +2385,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+ "serde",
 ]
 
 [[package]]
@@ -2425,15 +2525,19 @@ dependencies = [
  "digest 0.10.7",
  "elliptic-curve 0.13.8",
  "rfc6979 0.4.0",
+ "serdect",
  "signature 2.2.0",
  "spki 0.7.3",
 ]
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "elliptic-curve"
@@ -2471,6 +2575,7 @@ dependencies = [
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "sec1 0.7.3",
+ "serdect",
  "subtle",
  "zeroize",
 ]
@@ -2651,9 +2756,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -2822,9 +2927,9 @@ checksum = "42012b0f064e01aa58b545fe3727f90f7dd4020f4a3ea735b50344965f5a57e9"
 
 [[package]]
 name = "gcloud-sdk"
-version = "0.25.8"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0775bfa745cdf7287ae9765a685a813b91049b6b6d5ca3de20a3d5d16a80d8b2"
+checksum = "a6392faf01950e198a204b13034efd7aadda1877e7c174f5442ee39bad5d99bd"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2881,6 +2986,18 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -3014,12 +3131,6 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-
-[[package]]
-name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
@@ -3056,12 +3167,6 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "hex-literal"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hidapi-rusb"
@@ -3514,6 +3619,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -3672,7 +3778,7 @@ dependencies = [
  "http-body-util",
  "jsonrpsee-types",
  "pin-project 1.1.7",
- "rustc-hash 2.0.0",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -3793,6 +3899,7 @@ dependencies = [
  "ecdsa 0.16.9",
  "elliptic-curve 0.13.8",
  "once_cell",
+ "serdect",
  "sha2",
  "signature 2.2.0",
 ]
@@ -3892,11 +3999,22 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
 dependencies = [
  "hashbrown 0.15.2",
+]
+
+[[package]]
+name = "macro-string"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -4548,7 +4666,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -4734,7 +4852,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.0.0",
+ "rustc-hash 2.1.1",
  "rustls",
  "socket2",
  "thiserror 2.0.11",
@@ -4752,7 +4870,7 @@ dependencies = [
  "getrandom 0.2.15",
  "rand 0.8.5",
  "ring",
- "rustc-hash 2.0.0",
+ "rustc-hash 2.1.1",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -4784,6 +4902,12 @@ checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "radium"
@@ -4830,6 +4954,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+ "zerocopy 0.8.23",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4847,6 +4982,16 @@ checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -4880,6 +5025,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.2",
 ]
 
 [[package]]
@@ -5182,9 +5336,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc-hex"
@@ -5377,17 +5531,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schnellru"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9a8ef13a93c54d20580de1e5c413e624e53121d42fc7e2c11d10ef7f8b02367"
-dependencies = [
- "ahash",
- "cfg-if",
- "hashbrown 0.13.2",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5417,6 +5560,7 @@ dependencies = [
  "der 0.7.9",
  "generic-array",
  "pkcs8 0.10.2",
+ "serdect",
  "subtle",
  "zeroize",
 ]
@@ -5619,7 +5763,25 @@ checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
 dependencies = [
  "hex",
  "serde",
- "serde_with_macros",
+ "serde_with_macros 1.5.2",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.6.0",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with_macros 3.12.0",
+ "time",
 ]
 
 [[package]]
@@ -5628,10 +5790,32 @@ version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
 dependencies = [
- "darling",
+ "darling 0.13.4",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
+dependencies = [
+ "darling 0.20.10",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "serdect"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+dependencies = [
+ "base16ct 0.2.0",
+ "serde",
 ]
 
 [[package]]
@@ -5868,7 +6052,16 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
+dependencies = [
+ "strum_macros 0.27.1",
 ]
 
 [[package]]
@@ -5876,6 +6069,19 @@ name = "strum_macros"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -5914,9 +6120,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "0.8.15"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219389c1ebe89f8333df8bdfb871f6631c552ff399c23cac02480b6088aad8f0"
+checksum = "d975606bae72d8aad5b07d9342465e123a2cccf53a5a735aedf81ca92a709ecb"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -6216,9 +6422,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.24.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
 dependencies = [
  "futures-util",
  "log",
@@ -6478,21 +6684,20 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.24.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
 dependencies = [
- "byteorder",
  "bytes",
  "data-encoding",
  "http 1.1.0",
  "httparse",
  "log",
- "rand 0.8.5",
+ "rand 0.9.0",
  "rustls",
  "rustls-pki-types",
  "sha1",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
  "utf-8",
 ]
 
@@ -6740,6 +6945,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -7053,6 +7267,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags 2.6.0",
+]
+
+[[package]]
 name = "write16"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7129,7 +7361,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd97444d05a4328b90e75e503a34bad781f14e28a823ad3557f0750df1ebcbc6"
+dependencies = [
+ "zerocopy-derive 0.8.23",
 ]
 
 [[package]]
@@ -7137,6 +7378,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7401,8 +7653,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_json_path_to_error",
- "strum",
- "strum_macros",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
  "syn 2.0.98",
  "tera",
  "thiserror 1.0.69",
@@ -7448,9 +7700,9 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
- "serde_with",
+ "serde_with 1.14.0",
  "sha2",
- "strum",
+ "strum 0.26.3",
  "thiserror 1.0.69",
  "tiny-keccak 2.0.2",
  "url",
@@ -7564,8 +7816,8 @@ dependencies = [
  "lazy_static",
  "serde",
  "serde_json",
- "strum",
- "strum_macros",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
  "zksync-error-description",
 ]
 
@@ -7672,7 +7924,7 @@ dependencies = [
  "rlp",
  "serde",
  "serde_json",
- "serde_with",
+ "serde_with 1.14.0",
  "thiserror 1.0.69",
  "tracing",
  "zksync_basic_types",

--- a/e2e-tests-rust/Cargo.lock
+++ b/e2e-tests-rust/Cargo.lock
@@ -837,7 +837,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-zksync"
-version = "0.12.1"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a58db6b5d1f355325513b26f3d2253ebb8b7d2ed62f16c0022443b3159fbc7"
 dependencies = [
  "alloy",
  "async-trait",

--- a/e2e-tests-rust/Cargo.toml
+++ b/e2e-tests-rust/Cargo.toml
@@ -11,8 +11,8 @@ publish = false
 
 [dependencies]
 # Keep `alloy-zksync` version in sync with base `alloy` crate to avoid two different sets of dependencies
-alloy-zksync = "0.9.0"
-alloy = { version = "0.9.2", features = ["full", "rlp", "serde", "getrandom", "provider-anvil-api", "provider-anvil-node", "json-rpc", "contract"] }
+alloy-zksync = { path = "../../alloy-zksync" }
+alloy = { version = "0.12.4", features = ["full", "rlp", "serde", "getrandom", "provider-anvil-api", "provider-anvil-node", "json-rpc", "contract"] }
 
 anyhow = "1.0"
 fs2 = "0.4.3"

--- a/e2e-tests-rust/Cargo.toml
+++ b/e2e-tests-rust/Cargo.toml
@@ -11,8 +11,8 @@ publish = false
 
 [dependencies]
 # Keep `alloy-zksync` version in sync with base `alloy` crate to avoid two different sets of dependencies
-alloy-zksync = { path = "../../alloy-zksync" }
-alloy = { version = "0.12.4", features = ["full", "rlp", "serde", "getrandom", "provider-anvil-api", "provider-anvil-node", "json-rpc", "contract"] }
+alloy-zksync = "0.12.5"
+alloy = { version = "0.12.5", features = ["full", "rlp", "serde", "getrandom", "provider-anvil-api", "provider-anvil-node", "json-rpc", "contract"] }
 
 anyhow = "1.0"
 fs2 = "0.4.3"

--- a/e2e-tests-rust/src/headers_inspector.rs
+++ b/e2e-tests-rust/src/headers_inspector.rs
@@ -1,0 +1,28 @@
+use async_trait::async_trait;
+use http::HeaderMap;
+use reqwest_middleware::{Middleware, Next};
+use std::sync::{Arc, RwLock};
+
+/// A [`reqwest_middleware`]-compliant middleware that allows to inspect last seen response headers.
+#[derive(Clone, Debug, Default)]
+pub struct ResponseHeadersInspector(Arc<RwLock<Option<HeaderMap>>>);
+
+impl ResponseHeadersInspector {
+    pub fn last_unwrap(&self) -> HeaderMap {
+        self.0.read().unwrap().clone().expect("no headers found")
+    }
+}
+
+#[async_trait]
+impl Middleware for ResponseHeadersInspector {
+    async fn handle(
+        &self,
+        req: reqwest::Request,
+        extensions: &mut http::Extensions,
+        next: Next<'_>,
+    ) -> reqwest_middleware::Result<reqwest::Response> {
+        let resp = next.run(req, extensions).await?;
+        *self.0.write().unwrap() = Some(resp.headers().clone());
+        Ok(resp)
+    }
+}

--- a/e2e-tests-rust/src/lib.rs
+++ b/e2e-tests-rust/src/lib.rs
@@ -2,12 +2,14 @@
 
 pub mod contracts;
 mod ext;
-pub mod http_middleware;
+mod headers_inspector;
+mod http_middleware;
 mod provider;
 pub mod test_contracts;
 mod utils;
 
 pub use ext::{ReceiptExt, ZksyncWalletProviderExt};
+pub use headers_inspector::ResponseHeadersInspector;
 pub use provider::{
     AnvilZKsyncApi, FullZksyncProvider, TestingProvider, TestingProviderBuilder, DEFAULT_TX_VALUE,
 };

--- a/e2e-tests-rust/src/lib.rs
+++ b/e2e-tests-rust/src/lib.rs
@@ -9,7 +9,6 @@ mod utils;
 
 pub use ext::{ReceiptExt, ZksyncWalletProviderExt};
 pub use provider::{
-    init_testing_provider, init_testing_provider_with_client, AnvilZKsyncApi, FullZksyncProvider,
-    TestingProvider, DEFAULT_TX_VALUE,
+    AnvilZKsyncApi, FullZksyncProvider, TestingProvider, TestingProviderBuilder, DEFAULT_TX_VALUE,
 };
 pub use utils::{get_node_binary_path, LockedPort};

--- a/e2e-tests-rust/src/lib.rs
+++ b/e2e-tests-rust/src/lib.rs
@@ -11,6 +11,7 @@ mod utils;
 pub use ext::{ReceiptExt, ZksyncWalletProviderExt};
 pub use headers_inspector::ResponseHeadersInspector;
 pub use provider::{
-    AnvilZKsyncApi, FullZksyncProvider, TestingProvider, TestingProviderBuilder, DEFAULT_TX_VALUE,
+    AnvilZKsyncApi, AnvilZksyncTester, AnvilZksyncTesterBuilder, FullZksyncProvider,
+    DEFAULT_TX_VALUE,
 };
 pub use utils::{get_node_binary_path, LockedPort};

--- a/e2e-tests-rust/src/provider/anvil_zksync.rs
+++ b/e2e-tests-rust/src/provider/anvil_zksync.rs
@@ -3,21 +3,17 @@ use alloy::primitives::TxHash;
 use alloy::providers::{Provider, ProviderCall};
 use alloy::rpc::client::NoParams;
 use alloy::serde::WithOtherFields;
-use alloy::transports::{Transport, TransportResult};
+use alloy::transports::TransportResult;
 use alloy_zksync::network::Zksync;
 
 /// RPC interface that gives access to methods specific to anvil-zksync.
 #[allow(clippy::type_complexity)]
-pub trait AnvilZKsyncApi<T>: Provider<T, Zksync>
-where
-    T: Transport + Clone,
-{
+pub trait AnvilZKsyncApi: Provider<Zksync> {
     /// Custom version of [`alloy::providers::ext::AnvilApi::anvil_mine_detailed`] that returns
     /// block representation with transactions that contain extra custom fields.
     fn anvil_zksync_mine_detailed(
         &self,
     ) -> ProviderCall<
-        T,
         NoParams,
         alloy::rpc::types::Block<
             WithOtherFields<<Zksync as Network>::TransactionResponse>,
@@ -49,9 +45,4 @@ where
     }
 }
 
-impl<P, T> AnvilZKsyncApi<T> for P
-where
-    T: Transport + Clone,
-    P: Provider<T, Zksync>,
-{
-}
+impl<P> AnvilZKsyncApi for P where P: Provider<Zksync> {}

--- a/e2e-tests-rust/src/provider/mod.rs
+++ b/e2e-tests-rust/src/provider/mod.rs
@@ -2,4 +2,6 @@ mod anvil_zksync;
 mod testing;
 
 pub use anvil_zksync::AnvilZKsyncApi;
-pub use testing::{FullZksyncProvider, TestingProvider, TestingProviderBuilder, DEFAULT_TX_VALUE};
+pub use testing::{
+    AnvilZksyncTester, AnvilZksyncTesterBuilder, FullZksyncProvider, DEFAULT_TX_VALUE,
+};

--- a/e2e-tests-rust/src/provider/mod.rs
+++ b/e2e-tests-rust/src/provider/mod.rs
@@ -2,7 +2,4 @@ mod anvil_zksync;
 mod testing;
 
 pub use anvil_zksync::AnvilZKsyncApi;
-pub use testing::{
-    init_testing_provider, init_testing_provider_with_client, FullZksyncProvider, TestingProvider,
-    DEFAULT_TX_VALUE,
-};
+pub use testing::{FullZksyncProvider, TestingProvider, TestingProviderBuilder, DEFAULT_TX_VALUE};

--- a/e2e-tests-rust/src/test_contracts/mod.rs
+++ b/e2e-tests-rust/src/test_contracts/mod.rs
@@ -2,7 +2,6 @@ use alloy::contract::SolCallBuilder;
 use alloy::network::ReceiptResponse;
 use alloy::primitives::{Address, U256};
 use alloy::providers::Provider;
-use alloy::transports::Transport;
 use alloy_zksync::network::transaction_request::TransactionRequest;
 use alloy_zksync::network::Zksync;
 use std::fmt::Debug;
@@ -16,11 +15,9 @@ mod private {
     );
 }
 
-pub struct Counter<T: Transport + Clone, P: Provider<T, Zksync>>(
-    private::Counter::CounterInstance<T, P, Zksync>,
-);
+pub struct Counter<P: Provider<Zksync>>(private::Counter::CounterInstance<(), P, Zksync>);
 
-impl<T: Transport + Clone, P: Provider<T, Zksync>> Counter<T, P> {
+impl<P: Provider<Zksync>> Counter<P> {
     pub async fn deploy(provider: P) -> anyhow::Result<Self> {
         let tx = TransactionRequest::default().with_create_params(
             private::Counter::BYTECODE.clone().into(),
@@ -46,7 +43,7 @@ impl<T: Transport + Clone, P: Provider<T, Zksync>> Counter<T, P> {
     pub fn increment(
         &self,
         x: impl TryInto<U256, Error = impl Debug>,
-    ) -> SolCallBuilder<T, &P, private::Counter::incrementCall, Zksync> {
+    ) -> SolCallBuilder<(), &P, private::Counter::incrementCall, Zksync> {
         self.0.increment(x.try_into().unwrap())
     }
 }

--- a/e2e-tests-rust/tests/l1.rs
+++ b/e2e-tests-rust/tests/l1.rs
@@ -1,70 +1,55 @@
-use alloy::network::{Ethereum, ReceiptResponse, TransactionBuilder};
+use alloy::network::{ReceiptResponse, TransactionBuilder};
 use alloy::primitives::{Address, B256, U256};
-use alloy::providers::{Provider, ProviderBuilder, WalletProvider};
+use alloy::providers::{Provider, WalletProvider};
 use alloy_zksync::network::receipt_response::ReceiptResponse as ZkReceiptResponse;
 use alloy_zksync::provider::ZksyncProvider;
 use anvil_zksync_e2e_tests::contracts::{Bridgehub, L1Messenger, L2Message};
 use anvil_zksync_e2e_tests::test_contracts::Counter;
-use anvil_zksync_e2e_tests::{
-    AnvilZKsyncApi, FullZksyncProvider, LockedPort, ReceiptExt, TestingProvider,
-    TestingProviderBuilder,
-};
+use anvil_zksync_e2e_tests::{AnvilZKsyncApi, AnvilZksyncTesterBuilder, ReceiptExt};
 use anyhow::Context;
 use std::str::FromStr;
 
-async fn init_l1_l2_providers() -> anyhow::Result<(
-    impl Provider<Ethereum> + Clone,
-    TestingProvider<impl FullZksyncProvider>,
-)> {
-    let l1_locked_port = LockedPort::acquire_unused().await?;
-    let l1_provider = ProviderBuilder::new().on_anvil_with_config(|anvil| {
-        anvil
-            .port(l1_locked_port.port)
-            .arg("--no-request-size-limit")
-    });
-    let l1_address = format!("http://localhost:{}", l1_locked_port.port);
-    let l2_provider = TestingProviderBuilder::default()
-        .with_node_fn(&|node| node.args(["--external-l1", l1_address.as_str()]))
+#[tokio::test]
+async fn commit_batch_to_l1() -> anyhow::Result<()> {
+    let tester = AnvilZksyncTesterBuilder::default()
+        .with_l1()
         .build()
         .await?;
 
     // Pre-generate a few batches for the rest of the test
     for _ in 0..5 {
-        l2_provider.tx().finalize().await?.assert_successful()?;
+        tester.tx().finalize().await?.assert_successful()?;
     }
 
-    Ok((l1_provider, l2_provider))
-}
-
-#[tokio::test]
-async fn commit_batch_to_l1() -> anyhow::Result<()> {
-    let (l1_provider, l2_provider) = init_l1_l2_providers().await?;
-
     // Committing first batch after genesis should work
-    let tx_hash = l2_provider.anvil_commit_batch(1).await?;
-    let receipt = l1_provider
+    let tx_hash = tester.l2_provider().anvil_commit_batch(1).await?;
+    let receipt = tester
+        .l1_provider()
         .get_transaction_receipt(tx_hash)
         .await?
         .expect("receipt not found on L1");
     assert!(receipt.status());
 
     // Committing same batch twice shouldn't work
-    let error = l2_provider
+    let error = tester
+        .l2_provider()
         .anvil_commit_batch(1)
         .await
         .expect_err("commit batch expected to fail");
     assert!(error.to_string().contains("commit transaction failed"));
 
     // Next batch is committable
-    let tx_hash = l2_provider.anvil_commit_batch(2).await?;
-    let receipt = l1_provider
+    let tx_hash = tester.l2_provider().anvil_commit_batch(2).await?;
+    let receipt = tester
+        .l1_provider()
         .get_transaction_receipt(tx_hash)
         .await?
         .expect("receipt not found on L1");
     assert!(receipt.status());
 
     // Skipping a batch shouldn't work
-    let error = l2_provider
+    let error = tester
+        .l2_provider()
         .anvil_commit_batch(4)
         .await
         .expect_err("commit batch expected to fail");
@@ -75,42 +60,55 @@ async fn commit_batch_to_l1() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn prove_batch_on_l1() -> anyhow::Result<()> {
-    let (l1_provider, l2_provider) = init_l1_l2_providers().await?;
+    let tester = AnvilZksyncTesterBuilder::default()
+        .with_l1()
+        .build()
+        .await?;
+
+    // Pre-generate a few batches for the rest of the test
+    for _ in 0..5 {
+        tester.tx().finalize().await?.assert_successful()?;
+    }
 
     // Proving batch without committing shouldn't work
-    let error = l2_provider
+    let error = tester
+        .l2_provider()
         .anvil_prove_batch(1)
         .await
         .expect_err("prove batch expected to fail");
     assert!(error.to_string().contains("prove transaction failed"));
 
     // Commit & prove first batch after genesis
-    l2_provider.anvil_commit_batch(1).await?;
-    let tx_hash = l2_provider.anvil_prove_batch(1).await?;
-    let receipt = l1_provider
+    tester.l2_provider().anvil_commit_batch(1).await?;
+    let tx_hash = tester.l2_provider().anvil_prove_batch(1).await?;
+    let receipt = tester
+        .l1_provider()
         .get_transaction_receipt(tx_hash)
         .await?
         .expect("receipt not found on L1");
     assert!(receipt.status());
 
     // Proving same batch twice shouldn't work
-    let error = l2_provider
+    let error = tester
+        .l2_provider()
         .anvil_prove_batch(1)
         .await
         .expect_err("prove batch expected to fail");
     assert!(error.to_string().contains("prove transaction failed"));
 
     // Commit & prove next batch
-    l2_provider.anvil_commit_batch(2).await?;
-    let tx_hash = l2_provider.anvil_prove_batch(2).await?;
-    let receipt = l1_provider
+    tester.l2_provider().anvil_commit_batch(2).await?;
+    let tx_hash = tester.l2_provider().anvil_prove_batch(2).await?;
+    let receipt = tester
+        .l1_provider()
         .get_transaction_receipt(tx_hash)
         .await?
         .expect("receipt not found on L1");
     assert!(receipt.status());
 
     // Skipping a batch shouldn't work
-    let error = l2_provider
+    let error = tester
+        .l2_provider()
         .anvil_prove_batch(4)
         .await
         .expect_err("prove batch expected to fail");
@@ -121,51 +119,65 @@ async fn prove_batch_on_l1() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn execute_batch_on_l1() -> anyhow::Result<()> {
-    let (l1_provider, l2_provider) = init_l1_l2_providers().await?;
+    let tester = AnvilZksyncTesterBuilder::default()
+        .with_l1()
+        .build()
+        .await?;
+
+    // Pre-generate a few batches for the rest of the test
+    for _ in 0..5 {
+        tester.tx().finalize().await?.assert_successful()?;
+    }
 
     // Executing batch without committing shouldn't work
-    let error = l2_provider
+    let error = tester
+        .l2_provider()
         .anvil_execute_batch(1)
         .await
         .expect_err("execute batch expected to fail");
     assert!(error.to_string().contains("execute transaction failed"));
 
     // Committing is not enough for executing
-    l2_provider.anvil_commit_batch(1).await?;
-    let error = l2_provider
+    tester.l2_provider().anvil_commit_batch(1).await?;
+    let error = tester
+        .l2_provider()
         .anvil_execute_batch(1)
         .await
         .expect_err("execute batch expected to fail");
     assert!(error.to_string().contains("execute transaction failed"));
 
     // Prove & commit first batch after genesis
-    l2_provider.anvil_prove_batch(1).await?;
-    let tx_hash = l2_provider.anvil_execute_batch(1).await?;
-    let receipt = l1_provider
+    tester.l2_provider().anvil_prove_batch(1).await?;
+    let tx_hash = tester.l2_provider().anvil_execute_batch(1).await?;
+    let receipt = tester
+        .l1_provider()
         .get_transaction_receipt(tx_hash)
         .await?
         .expect("receipt not found on L1");
     assert!(receipt.status());
 
     // Executing same batch twice shouldn't work
-    let error = l2_provider
+    let error = tester
+        .l2_provider()
         .anvil_execute_batch(1)
         .await
         .expect_err("execute batch expected to fail");
     assert!(error.to_string().contains("execute transaction failed"));
 
     // Commit & prove & execute next batch
-    l2_provider.anvil_commit_batch(2).await?;
-    l2_provider.anvil_prove_batch(2).await?;
-    let tx_hash = l2_provider.anvil_execute_batch(2).await?;
-    let receipt = l1_provider
+    tester.l2_provider().anvil_commit_batch(2).await?;
+    tester.l2_provider().anvil_prove_batch(2).await?;
+    let tx_hash = tester.l2_provider().anvil_execute_batch(2).await?;
+    let receipt = tester
+        .l1_provider()
         .get_transaction_receipt(tx_hash)
         .await?
         .expect("receipt not found on L1");
     assert!(receipt.status());
 
     // Skipping a batch shouldn't work
-    let error = l2_provider
+    let error = tester
+        .l2_provider()
         .anvil_execute_batch(4)
         .await
         .expect_err("execute batch expected to fail");
@@ -176,10 +188,13 @@ async fn execute_batch_on_l1() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn send_l2_to_l1_message() -> anyhow::Result<()> {
-    let (l1_provider, l2_provider) = init_l1_l2_providers().await?;
+    let tester = AnvilZksyncTesterBuilder::default()
+        .with_l1()
+        .build()
+        .await?;
 
     let message = "Some L2->L1 message";
-    let l1_messenger = L1Messenger::new(l2_provider.clone());
+    let l1_messenger = L1Messenger::new(tester.l2_provider().clone());
     let msg_tx_receipt: ZkReceiptResponse = l1_messenger
         .send_to_l1(message)
         .send()
@@ -194,12 +209,13 @@ async fn send_l2_to_l1_message() -> anyhow::Result<()> {
     let log = &msg_tx_receipt.l2_to_l1_logs()[0];
     assert_eq!(&log.sender, l1_messenger.address());
 
-    let bridgehub = Bridgehub::new(l1_provider.clone(), &l2_provider).await?;
+    let bridgehub = Bridgehub::new(tester.l1_provider(), tester.l2_provider()).await?;
     let log_batch_number: u64 = msg_tx_receipt
         .l1_batch_number()
         .context("missing L1 batch number")?
         .try_into()?;
-    let msg_proof = l2_provider
+    let msg_proof = tester
+        .l2_provider()
         .get_l2_to_l1_log_proof(
             msg_tx_receipt.transaction_hash(),
             Some(log.log_index.try_into()?),
@@ -211,7 +227,7 @@ async fn send_l2_to_l1_message() -> anyhow::Result<()> {
             .l1_batch_tx_index()
             .context("missing L1 batch tx index")?
             .try_into()?,
-        sender: l2_provider.default_signer_address(),
+        sender: tester.l2_provider().default_signer_address(),
         data: message.into(),
     };
     let prove_inclusion_call = bridgehub.prove_l2_message_inclusion(
@@ -226,9 +242,15 @@ async fn send_l2_to_l1_message() -> anyhow::Result<()> {
 
     // Execute all batches up to the one including the log
     for batch_number in 1..=log_batch_number {
-        l2_provider.anvil_commit_batch(batch_number).await?;
-        l2_provider.anvil_prove_batch(batch_number).await?;
-        l2_provider.anvil_execute_batch(batch_number).await?;
+        tester
+            .l2_provider()
+            .anvil_commit_batch(batch_number)
+            .await?;
+        tester.l2_provider().anvil_prove_batch(batch_number).await?;
+        tester
+            .l2_provider()
+            .anvil_execute_batch(batch_number)
+            .await?;
     }
 
     // Inclusion check succeeds as the batch has been executed
@@ -250,15 +272,18 @@ async fn send_l2_to_l1_message() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn l1_priority_tx() -> anyhow::Result<()> {
-    let (l1_provider, l2_provider) = init_l1_l2_providers().await?;
+    let tester = AnvilZksyncTesterBuilder::default()
+        .with_l1()
+        .build()
+        .await?;
 
     // Deploy `Counter` contract and validate that it is initialized with `0`
-    let counter = Counter::deploy(l2_provider.clone()).await?;
+    let counter = Counter::deploy(tester.l2_provider().clone()).await?;
     assert_eq!(counter.get().await?, U256::from(0));
 
     // Prepare a transaction from a rich account that will increment `Counter` by 1
     let alice = Address::from_str("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266")?;
-    let eip1559_est = l1_provider.estimate_eip1559_fees().await?;
+    let eip1559_est = tester.l1_provider().estimate_eip1559_fees().await?;
     let tx = counter
         .increment(1)
         .into_transaction_request()
@@ -266,9 +291,9 @@ async fn l1_priority_tx() -> anyhow::Result<()> {
         .with_max_fee_per_gas(eip1559_est.max_fee_per_gas);
 
     // But submit it as an L1 transaction through Bridgehub
-    let bridgehub = Bridgehub::new(l1_provider.clone(), &l2_provider).await?;
+    let bridgehub = Bridgehub::new(tester.l1_provider().clone(), tester.l2_provider()).await?;
     bridgehub
-        .request_execute(&l2_provider, tx.clone())
+        .request_execute(tester.l2_provider(), tx.clone())
         .await?
         .watch()
         .await?;

--- a/e2e-tests-rust/tests/l1.rs
+++ b/e2e-tests-rust/tests/l1.rs
@@ -6,8 +6,8 @@ use alloy_zksync::provider::ZksyncProvider;
 use anvil_zksync_e2e_tests::contracts::{Bridgehub, L1Messenger, L2Message};
 use anvil_zksync_e2e_tests::test_contracts::Counter;
 use anvil_zksync_e2e_tests::{
-    init_testing_provider, AnvilZKsyncApi, FullZksyncProvider, LockedPort, ReceiptExt,
-    TestingProvider,
+    AnvilZKsyncApi, FullZksyncProvider, LockedPort, ReceiptExt, TestingProvider,
+    TestingProviderBuilder,
 };
 use anyhow::Context;
 use std::str::FromStr;
@@ -23,9 +23,10 @@ async fn init_l1_l2_providers() -> anyhow::Result<(
             .arg("--no-request-size-limit")
     });
     let l1_address = format!("http://localhost:{}", l1_locked_port.port);
-    let l2_provider =
-        init_testing_provider(move |node| node.args(["--external-l1", l1_address.as_str()]))
-            .await?;
+    let l2_provider = TestingProviderBuilder::default()
+        .with_node_fn(move |node| node.args(["--external-l1", l1_address.as_str()]))
+        .build()
+        .await?;
 
     // Pre-generate a few batches for the rest of the test
     for _ in 0..5 {

--- a/e2e-tests-rust/tests/l1.rs
+++ b/e2e-tests-rust/tests/l1.rs
@@ -24,7 +24,7 @@ async fn init_l1_l2_providers() -> anyhow::Result<(
     });
     let l1_address = format!("http://localhost:{}", l1_locked_port.port);
     let l2_provider = TestingProviderBuilder::default()
-        .with_node_fn(move |node| node.args(["--external-l1", l1_address.as_str()]))
+        .with_node_fn(&|node| node.args(["--external-l1", l1_address.as_str()]))
         .build()
         .await?;
 

--- a/e2e-tests-rust/tests/lib.rs
+++ b/e2e-tests-rust/tests/lib.rs
@@ -1,9 +1,7 @@
 use alloy::network::ReceiptResponse;
 use alloy::providers::ext::AnvilApi;
 use alloy::providers::Provider;
-use alloy::{
-    network::primitives::BlockTransactionsKind, primitives::U256, signers::local::PrivateKeySigner,
-};
+use alloy::{primitives::U256, signers::local::PrivateKeySigner};
 use alloy_zksync::node_bindings::AnvilZKsync;
 use anvil_zksync_core::node::VersionedState;
 use anvil_zksync_core::utils::write_json_file;
@@ -488,12 +486,9 @@ async fn pool_txs_order_fifo() -> anyhow::Result<()> {
         .register()
         .await?;
 
-    provider_fifo.anvil_mine(Some(U256::from(1)), None).await?;
+    provider_fifo.anvil_mine(Some(1), None).await?;
 
-    let block = provider_fifo
-        .get_block(1.into(), BlockTransactionsKind::Hashes)
-        .await?
-        .unwrap();
+    let block = provider_fifo.get_block(1.into()).await?.unwrap();
     let tx_hashes = block.transactions.as_hashes().unwrap();
     assert_eq!(&tx_hashes[0], pending_tx0.tx_hash());
     assert_eq!(&tx_hashes[1], pending_tx1.tx_hash());
@@ -524,12 +519,9 @@ async fn pool_txs_order_fees() -> anyhow::Result<()> {
         .register()
         .await?;
 
-    provider_fees.anvil_mine(Some(U256::from(1)), None).await?;
+    provider_fees.anvil_mine(Some(1), None).await?;
 
-    let block = provider_fees
-        .get_block(1.into(), BlockTransactionsKind::Hashes)
-        .await?
-        .unwrap();
+    let block = provider_fees.get_block(1.into()).await?.unwrap();
     let tx_hashes = block.transactions.as_hashes().unwrap();
     assert_eq!(&tx_hashes[0], pending_tx2.tx_hash());
     assert_eq!(&tx_hashes[1], pending_tx1.tx_hash());
@@ -543,7 +535,7 @@ async fn transactions_have_index() -> anyhow::Result<()> {
     let tx1 = provider.tx().with_rich_from(0).register().await?;
     let tx2 = provider.tx().with_rich_from(1).register().await?;
 
-    provider.anvil_mine(Some(U256::from(1)), None).await?;
+    provider.anvil_mine(Some(1), None).await?;
 
     let receipt1 = tx1.wait_until_finalized().await?;
     let receipt2 = tx2.wait_until_finalized().await?;

--- a/e2e-tests-rust/tests/lib.rs
+++ b/e2e-tests-rust/tests/lib.rs
@@ -6,8 +6,8 @@ use alloy_zksync::node_bindings::AnvilZKsync;
 use anvil_zksync_core::node::VersionedState;
 use anvil_zksync_core::utils::write_json_file;
 use anvil_zksync_e2e_tests::{
-    get_node_binary_path, AnvilZKsyncApi, LockedPort, ReceiptExt, ResponseHeadersInspector,
-    TestingProviderBuilder, ZksyncWalletProviderExt, DEFAULT_TX_VALUE,
+    get_node_binary_path, AnvilZKsyncApi, AnvilZksyncTesterBuilder, LockedPort, ReceiptExt,
+    ResponseHeadersInspector, ZksyncWalletProviderExt, DEFAULT_TX_VALUE,
 };
 use anyhow::Context;
 use flate2::read::GzDecoder;
@@ -28,12 +28,12 @@ const ANY_ORIGIN: HeaderValue = HeaderValue::from_static("*");
 async fn interval_sealing_finalization() -> anyhow::Result<()> {
     // Test that we can submit a transaction and wait for it to finalize when anvil-zksync is
     // operating in interval sealing mode.
-    let provider = TestingProviderBuilder::default()
+    let tester = AnvilZksyncTesterBuilder::default()
         .with_node_fn(&|node| node.block_time(1))
         .build()
         .await?;
 
-    provider.tx().finalize().await?.assert_successful()?;
+    tester.tx().finalize().await?.assert_successful()?;
 
     Ok(())
 }
@@ -43,12 +43,12 @@ async fn interval_sealing_multiple_txs() -> anyhow::Result<()> {
     // Test that we can submit two transactions and wait for them to finalize in the same block when
     // anvil-zksync is operating in interval sealing mode. 3 seconds should be long enough for
     // the entire flow to execute before the first block is produced.
-    let provider = TestingProviderBuilder::default()
+    let tester = AnvilZksyncTesterBuilder::default()
         .with_node_fn(&|node| node.block_time(3))
         .build()
         .await?;
 
-    provider
+    tester
         .race_n_txs_rich::<2>()
         .await?
         .assert_successful()?
@@ -61,18 +61,18 @@ async fn interval_sealing_multiple_txs() -> anyhow::Result<()> {
 async fn no_sealing_timeout() -> anyhow::Result<()> {
     // Test that we can submit a transaction and timeout while waiting for it to finalize when
     // anvil-zksync is operating in no sealing mode.
-    let provider = TestingProviderBuilder::default()
+    let tester = AnvilZksyncTesterBuilder::default()
         .with_node_fn(&|node| node.no_mine())
         .build()
         .await?;
 
-    let pending_tx = provider.tx().register().await?;
+    let pending_tx = tester.tx().register().await?;
     let pending_tx = pending_tx
         .assert_not_finalizable(Duration::from_secs(3))
         .await?;
 
     // Mine a block manually and assert that the transaction is finalized now
-    provider.anvil_mine(None, None).await?;
+    tester.l2_provider().anvil_mine(None, None).await?;
     pending_tx
         .wait_until_finalized()
         .await?
@@ -84,37 +84,37 @@ async fn no_sealing_timeout() -> anyhow::Result<()> {
 #[tokio::test]
 async fn dynamic_sealing_mode() -> anyhow::Result<()> {
     // Test that we can successfully switch between different sealing modes
-    let provider = TestingProviderBuilder::default()
+    let tester = AnvilZksyncTesterBuilder::default()
         .with_node_fn(&|node| node.no_mine())
         .build()
         .await?;
-    assert!(!(provider.anvil_get_auto_mine().await?));
+    assert!(!tester.l2_provider().anvil_get_auto_mine().await?);
 
     // Enable immediate block sealing
-    provider.anvil_set_auto_mine(true).await?;
-    assert!(provider.anvil_get_auto_mine().await?);
+    tester.l2_provider().anvil_set_auto_mine(true).await?;
+    assert!(tester.l2_provider().anvil_get_auto_mine().await?);
 
     // Check that we can finalize transactions now
-    let receipt = provider.tx().finalize().await?;
+    let receipt = tester.tx().finalize().await?;
     assert!(receipt.status());
 
     // Enable interval block sealing
-    provider.anvil_set_interval_mining(3).await?;
-    assert!(!(provider.anvil_get_auto_mine().await?));
+    tester.l2_provider().anvil_set_interval_mining(3).await?;
+    assert!(!tester.l2_provider().anvil_get_auto_mine().await?);
 
     // Check that we can finalize two txs in the same block now
-    provider
+    tester
         .race_n_txs_rich::<2>()
         .await?
         .assert_successful()?
         .assert_same_block()?;
 
     // Disable block sealing entirely
-    provider.anvil_set_auto_mine(false).await?;
-    assert!(!(provider.anvil_get_auto_mine().await?));
+    tester.l2_provider().anvil_set_auto_mine(false).await?;
+    assert!(!tester.l2_provider().anvil_get_auto_mine().await?);
 
     // Check that transactions do not get finalized now
-    provider
+    tester
         .tx()
         .register()
         .await?
@@ -129,16 +129,17 @@ async fn drop_transaction() -> anyhow::Result<()> {
     // Test that we can submit two transactions and then remove one from the pool before it gets
     // finalized. 3 seconds should be long enough for the entire flow to execute before the first
     // block is produced.
-    let provider = TestingProviderBuilder::default()
+    let tester = AnvilZksyncTesterBuilder::default()
         .with_node_fn(&|node| node.block_time(3))
         .build()
         .await?;
 
-    let pending_tx0 = provider.tx().with_rich_from(0).register().await?;
-    let pending_tx1 = provider.tx().with_rich_from(1).register().await?;
+    let pending_tx0 = tester.tx().with_rich_from(0).register().await?;
+    let pending_tx1 = tester.tx().with_rich_from(1).register().await?;
 
     // Drop first
-    provider
+    tester
+        .l2_provider()
         .anvil_drop_transaction(*pending_tx0.tx_hash())
         .await?;
 
@@ -159,16 +160,16 @@ async fn drop_all_transactions() -> anyhow::Result<()> {
     // Test that we can submit two transactions and then remove them from the pool before they get
     // finalized. 3 seconds should be long enough for the entire flow to execute before the first
     // block is produced.
-    let provider = TestingProviderBuilder::default()
+    let tester = AnvilZksyncTesterBuilder::default()
         .with_node_fn(&|node| node.block_time(3))
         .build()
         .await?;
 
-    let pending_tx0 = provider.tx().with_rich_from(0).register().await?;
-    let pending_tx1 = provider.tx().with_rich_from(1).register().await?;
+    let pending_tx0 = tester.tx().with_rich_from(0).register().await?;
+    let pending_tx1 = tester.tx().with_rich_from(1).register().await?;
 
     // Drop all transactions
-    provider.anvil_drop_all_transactions().await?;
+    tester.l2_provider().anvil_drop_all_transactions().await?;
 
     // Neither transaction gets finalized
     pending_tx0
@@ -186,18 +187,19 @@ async fn remove_pool_transactions() -> anyhow::Result<()> {
     // Test that we can submit two transactions from two senders and then remove first sender's
     // transaction from the pool before it gets finalized. 3 seconds should be long enough for the
     // entire flow to execute before the first block is produced.
-    let provider = TestingProviderBuilder::default()
+    let tester = AnvilZksyncTesterBuilder::default()
         .with_node_fn(&|node| node.block_time(3))
         .build()
         .await?;
 
     // Submit two transactions
-    let pending_tx0 = provider.tx().with_rich_from(0).register().await?;
-    let pending_tx1 = provider.tx().with_rich_from(1).register().await?;
+    let pending_tx0 = tester.tx().with_rich_from(0).register().await?;
+    let pending_tx1 = tester.tx().with_rich_from(1).register().await?;
 
     // Drop first
-    provider
-        .anvil_remove_pool_transactions(provider.rich_account(0))
+    tester
+        .l2_provider()
+        .anvil_remove_pool_transactions(tester.rich_account(0))
         .await?;
 
     // Assert first never gets finalized but the second one does
@@ -216,16 +218,16 @@ async fn remove_pool_transactions() -> anyhow::Result<()> {
 async fn manual_mining_two_txs_in_one_block() -> anyhow::Result<()> {
     // Test that we can submit two transaction and then manually mine one block that contains both
     // transactions in it.
-    let provider = TestingProviderBuilder::default()
+    let tester = AnvilZksyncTesterBuilder::default()
         .with_node_fn(&|node| node.no_mine())
         .build()
         .await?;
 
-    let pending_tx0 = provider.tx().with_rich_from(0).register().await?;
-    let pending_tx1 = provider.tx().with_rich_from(1).register().await?;
+    let pending_tx0 = tester.tx().with_rich_from(0).register().await?;
+    let pending_tx1 = tester.tx().with_rich_from(1).register().await?;
 
     // Mine a block manually and assert that both transactions are finalized now
-    provider.anvil_mine(None, None).await?;
+    tester.l2_provider().anvil_mine(None, None).await?;
 
     let receipt0 = pending_tx0.wait_until_finalized().await?;
     receipt0.assert_successful()?;
@@ -239,15 +241,15 @@ async fn manual_mining_two_txs_in_one_block() -> anyhow::Result<()> {
 #[tokio::test]
 async fn detailed_mining_success() -> anyhow::Result<()> {
     // Test that we can call detailed mining after a successful transaction and match output from it.
-    let provider = TestingProviderBuilder::default()
+    let tester = AnvilZksyncTesterBuilder::default()
         .with_node_fn(&|node| node.no_mine())
         .build()
         .await?;
 
-    provider.tx().register().await?;
+    tester.tx().register().await?;
 
     // Mine a block manually and assert that it has our transaction with extra fields
-    let block = provider.anvil_zksync_mine_detailed().await?;
+    let block = tester.l2_provider().anvil_zksync_mine_detailed().await?;
     assert_eq!(block.transactions.len(), 1);
     let actual_tx = block
         .transactions
@@ -269,21 +271,25 @@ async fn detailed_mining_success() -> anyhow::Result<()> {
 async fn seal_block_ignoring_halted_transaction() -> anyhow::Result<()> {
     // Test that we can submit three transactions (1 and 3 are successful, 2 is halting). And then
     // observe a block that finalizes 1 and 3 while ignoring 2.
-    let mut provider = TestingProviderBuilder::default()
+    let mut tester = AnvilZksyncTesterBuilder::default()
         .with_node_fn(&|node| node.block_time(3))
         .build()
         .await?;
-    let random_account = provider.register_random_signer();
+    let random_account = tester.l2_provider_mut().register_random_signer();
 
     // Impersonate random account for now so that gas estimation works as expected
-    provider.anvil_impersonate_account(random_account).await?;
+    tester
+        .l2_provider()
+        .anvil_impersonate_account(random_account)
+        .await?;
 
-    let pending_tx0 = provider.tx().with_rich_from(0).register().await?;
-    let pending_tx1 = provider.tx().with_from(random_account).register().await?;
-    let pending_tx2 = provider.tx().with_rich_from(1).register().await?;
+    let pending_tx0 = tester.tx().with_rich_from(0).register().await?;
+    let pending_tx1 = tester.tx().with_from(random_account).register().await?;
+    let pending_tx2 = tester.tx().with_rich_from(1).register().await?;
 
     // Stop impersonating random account so that tx is going to halt
-    provider
+    tester
+        .l2_provider()
         .anvil_stop_impersonating_account(random_account)
         .await?;
 
@@ -307,31 +313,28 @@ async fn dump_and_load_state() -> anyhow::Result<()> {
     // Test that we can submit transactions, then dump state and shutdown the node. Following that we
     // should be able to spin up a new node and load state into it. Previous transactions/block should
     // be present on the new node along with the old state.
-    let provider = TestingProviderBuilder::default().build().await?;
+    let tester = AnvilZksyncTesterBuilder::default().build().await?;
 
-    let receipts = [
-        provider.tx().finalize().await?,
-        provider.tx().finalize().await?,
-    ];
-    let blocks = provider.get_blocks_by_receipts(&receipts).await?;
+    let receipts = [tester.tx().finalize().await?, tester.tx().finalize().await?];
+    let blocks = tester.get_blocks_by_receipts(&receipts).await?;
 
     // Dump node's state, re-create it and load old state
-    let state = provider.anvil_dump_state().await?;
-    let provider = TestingProviderBuilder::default().build().await?;
-    provider.anvil_load_state(state).await?;
+    let state = tester.l2_provider().anvil_dump_state().await?;
+    let tester = AnvilZksyncTesterBuilder::default().build().await?;
+    tester.l2_provider().anvil_load_state(state).await?;
 
     // Assert that new node has pre-restart receipts, blocks and state
-    provider.assert_has_receipts(&receipts).await?;
-    provider.assert_has_blocks(&blocks).await?;
-    provider
+    tester.assert_has_receipts(&receipts).await?;
+    tester.assert_has_blocks(&blocks).await?;
+    tester
         .assert_balance(receipts[0].sender()?, DEFAULT_TX_VALUE)
         .await?;
-    provider
+    tester
         .assert_balance(receipts[1].sender()?, DEFAULT_TX_VALUE)
         .await?;
 
     // Assert we can still finalize transactions after loading state
-    provider.tx().finalize().await?;
+    tester.tx().finalize().await?;
 
     Ok(())
 }
@@ -339,58 +342,48 @@ async fn dump_and_load_state() -> anyhow::Result<()> {
 #[tokio::test]
 async fn cant_load_into_existing_state() -> anyhow::Result<()> {
     // Test that we can't load new state into a node with existing state.
-    let provider = TestingProviderBuilder::default().build().await?;
+    let tester = AnvilZksyncTesterBuilder::default().build().await?;
 
-    let old_receipts = [
-        provider.tx().finalize().await?,
-        provider.tx().finalize().await?,
-    ];
-    let old_blocks = provider.get_blocks_by_receipts(&old_receipts).await?;
+    let old_receipts = [tester.tx().finalize().await?, tester.tx().finalize().await?];
+    let old_blocks = tester.get_blocks_by_receipts(&old_receipts).await?;
 
     // Dump node's state and re-create it
-    let state = provider.anvil_dump_state().await?;
-    let provider = TestingProviderBuilder::default().build().await?;
+    let state = tester.l2_provider().anvil_dump_state().await?;
+    let tester = AnvilZksyncTesterBuilder::default().build().await?;
 
-    let new_receipts = [
-        provider.tx().finalize().await?,
-        provider.tx().finalize().await?,
-    ];
-    let new_blocks = provider.get_blocks_by_receipts(&new_receipts).await?;
+    let new_receipts = [tester.tx().finalize().await?, tester.tx().finalize().await?];
+    let new_blocks = tester.get_blocks_by_receipts(&new_receipts).await?;
 
     // Load state into the new node, make sure it fails and assert that the node still has new
     // receipts, blocks and state.
-    assert!(provider.anvil_load_state(state).await.is_err());
-    provider.assert_has_receipts(&new_receipts).await?;
-    provider.assert_has_blocks(&new_blocks).await?;
-    provider
+    assert!(tester.l2_provider().anvil_load_state(state).await.is_err());
+    tester.assert_has_receipts(&new_receipts).await?;
+    tester.assert_has_blocks(&new_blocks).await?;
+    tester
         .assert_balance(new_receipts[0].sender()?, DEFAULT_TX_VALUE)
         .await?;
-    provider
+    tester
         .assert_balance(new_receipts[1].sender()?, DEFAULT_TX_VALUE)
         .await?;
 
     // Assert the node does not have old state
-    provider.assert_no_receipts(&old_receipts).await?;
-    provider.assert_no_blocks(&old_blocks).await?;
-    provider
-        .assert_balance(old_receipts[0].sender()?, 0)
-        .await?;
-    provider
-        .assert_balance(old_receipts[1].sender()?, 0)
-        .await?;
+    tester.assert_no_receipts(&old_receipts).await?;
+    tester.assert_no_blocks(&old_blocks).await?;
+    tester.assert_balance(old_receipts[0].sender()?, 0).await?;
+    tester.assert_balance(old_receipts[1].sender()?, 0).await?;
 
     Ok(())
 }
 
 #[tokio::test]
 async fn set_chain_id() -> anyhow::Result<()> {
-    let mut provider = TestingProviderBuilder::default().build().await?;
+    let mut tester = AnvilZksyncTesterBuilder::default().build().await?;
 
     let random_signer = PrivateKeySigner::random();
     let random_signer_address = random_signer.address();
 
     // Send transaction before changing chain id
-    provider
+    tester
         .tx()
         .with_to(random_signer_address)
         .with_value(U256::from(1e18 as u64))
@@ -399,15 +392,18 @@ async fn set_chain_id() -> anyhow::Result<()> {
 
     // Change chain id
     let new_chain_id = 123;
-    provider.anvil_set_chain_id(new_chain_id).await?;
+    tester
+        .l2_provider()
+        .anvil_set_chain_id(new_chain_id)
+        .await?;
 
     // Verify new chain id
-    assert_eq!(new_chain_id, provider.get_chain_id().await?);
+    assert_eq!(new_chain_id, tester.l2_provider().get_chain_id().await?);
 
     // Verify transactions can be executed after chain id change
     // Registering and using new signer to get new chain id applied
-    provider.register_signer(random_signer);
-    provider
+    tester.l2_provider_mut().register_signer(random_signer);
+    tester
         .tx()
         .with_from(random_signer_address)
         .with_chain_id(new_chain_id)
@@ -421,13 +417,13 @@ async fn set_chain_id() -> anyhow::Result<()> {
 async fn cli_no_cors() -> anyhow::Result<()> {
     // Verify all origins are allowed by default
     let response_inspector = ResponseHeadersInspector::default();
-    let provider = TestingProviderBuilder::default()
+    let tester = AnvilZksyncTesterBuilder::default()
         .with_client_middleware_fn(&|client_builder| {
             client_builder.with(response_inspector.clone())
         })
         .build()
         .await?;
-    provider.get_chain_id().await?;
+    tester.l2_provider().get_chain_id().await?;
     let resp_headers = response_inspector.last_unwrap();
     assert_eq!(
         resp_headers.get(ACCESS_CONTROL_ALLOW_ORIGIN),
@@ -436,8 +432,11 @@ async fn cli_no_cors() -> anyhow::Result<()> {
 
     // Making OPTIONS request reveals all access control settings
     let client = reqwest::Client::new();
-    let url = provider.url.clone();
-    let resp = client.request(reqwest::Method::OPTIONS, url).send().await?;
+    let l2_url = tester.l2_url.clone();
+    let resp = client
+        .request(reqwest::Method::OPTIONS, l2_url)
+        .send()
+        .await?;
     assert_eq!(
         resp.headers().get(ACCESS_CONTROL_ALLOW_METHODS),
         Some(&HeaderValue::from_static("GET,POST"))
@@ -450,18 +449,18 @@ async fn cli_no_cors() -> anyhow::Result<()> {
         resp.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN),
         Some(&ANY_ORIGIN)
     );
-    drop(provider);
+    drop(tester);
 
     // Verify access control is disabled with --no-cors
     let response_inspector_no_cors = ResponseHeadersInspector::default();
-    let provider_no_cors = TestingProviderBuilder::default()
+    let tester_no_cors = AnvilZksyncTesterBuilder::default()
         .with_node_fn(&|node| node.arg("--no-cors"))
         .with_client_middleware_fn(&|client_builder| {
             client_builder.with(response_inspector_no_cors.clone())
         })
         .build()
         .await?;
-    provider_no_cors.get_chain_id().await?;
+    tester_no_cors.l2_provider().get_chain_id().await?;
     let resp_headers = response_inspector_no_cors.last_unwrap();
     assert_eq!(resp_headers.get(ACCESS_CONTROL_ALLOW_ORIGIN), None);
 
@@ -474,7 +473,7 @@ async fn cli_allow_origin() -> anyhow::Result<()> {
 
     // Verify allowed origin can make requests
     let response_inspector = ResponseHeadersInspector::default();
-    let provider_with_allowed_origin = TestingProviderBuilder::default()
+    let tester_with_allowed_origin = AnvilZksyncTesterBuilder::default()
         .with_node_fn(&|node| node.arg(format!("--allow-origin={}", SOME_ORIGIN.to_str().unwrap())))
         .with_client_fn(&|client| client.default_headers(req_headers.clone()))
         .with_client_middleware_fn(&|client_builder| {
@@ -482,18 +481,21 @@ async fn cli_allow_origin() -> anyhow::Result<()> {
         })
         .build()
         .await?;
-    provider_with_allowed_origin.get_chain_id().await?;
+    tester_with_allowed_origin
+        .l2_provider()
+        .get_chain_id()
+        .await?;
     let resp_headers = response_inspector.last_unwrap();
     assert_eq!(
         resp_headers.get(ACCESS_CONTROL_ALLOW_ORIGIN),
         Some(&SOME_ORIGIN)
     );
-    drop(provider_with_allowed_origin);
+    drop(tester_with_allowed_origin);
 
     // Verify different origin are also allowed to make requests. CORS is reliant on the browser
     // to respect access control headers reported by the server.
     let response_inspector_not_allowed = ResponseHeadersInspector::default();
-    let provider_with_not_allowed_origin = TestingProviderBuilder::default()
+    let tester_with_not_allowed_origin = AnvilZksyncTesterBuilder::default()
         .with_node_fn(&|node| {
             node.arg(format!("--allow-origin={}", OTHER_ORIGIN.to_str().unwrap()))
         })
@@ -503,7 +505,10 @@ async fn cli_allow_origin() -> anyhow::Result<()> {
         })
         .build()
         .await?;
-    provider_with_not_allowed_origin.get_chain_id().await?;
+    tester_with_not_allowed_origin
+        .l2_provider()
+        .get_chain_id()
+        .await?;
     let resp_headers = response_inspector_not_allowed.last_unwrap();
     assert_eq!(
         resp_headers.get(ACCESS_CONTROL_ALLOW_ORIGIN),
@@ -515,33 +520,37 @@ async fn cli_allow_origin() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn pool_txs_order_fifo() -> anyhow::Result<()> {
-    let provider_fifo = TestingProviderBuilder::default()
+    let tester_fifo = AnvilZksyncTesterBuilder::default()
         .with_node_fn(&|node| node.no_mine())
         .build()
         .await?;
 
-    let pending_tx0 = provider_fifo
+    let pending_tx0 = tester_fifo
         .tx()
         .with_rich_from(0)
         .with_max_fee_per_gas(50_000_000)
         .register()
         .await?;
-    let pending_tx1 = provider_fifo
+    let pending_tx1 = tester_fifo
         .tx()
         .with_rich_from(1)
         .with_max_fee_per_gas(100_000_000)
         .register()
         .await?;
-    let pending_tx2 = provider_fifo
+    let pending_tx2 = tester_fifo
         .tx()
         .with_rich_from(2)
         .with_max_fee_per_gas(150_000_000)
         .register()
         .await?;
 
-    provider_fifo.anvil_mine(Some(1), None).await?;
+    tester_fifo.l2_provider().anvil_mine(Some(1), None).await?;
 
-    let block = provider_fifo.get_block(1.into()).await?.unwrap();
+    let block = tester_fifo
+        .l2_provider()
+        .get_block(1.into())
+        .await?
+        .unwrap();
     let tx_hashes = block.transactions.as_hashes().unwrap();
     assert_eq!(&tx_hashes[0], pending_tx0.tx_hash());
     assert_eq!(&tx_hashes[1], pending_tx1.tx_hash());
@@ -551,33 +560,37 @@ async fn pool_txs_order_fifo() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn pool_txs_order_fees() -> anyhow::Result<()> {
-    let provider_fees = TestingProviderBuilder::default()
+    let tester_fees = AnvilZksyncTesterBuilder::default()
         .with_node_fn(&|node| node.no_mine().arg("--order=fees"))
         .build()
         .await?;
 
-    let pending_tx0 = provider_fees
+    let pending_tx0 = tester_fees
         .tx()
         .with_rich_from(0)
         .with_max_fee_per_gas(50_000_000)
         .register()
         .await?;
-    let pending_tx1 = provider_fees
+    let pending_tx1 = tester_fees
         .tx()
         .with_rich_from(1)
         .with_max_fee_per_gas(100_000_000)
         .register()
         .await?;
-    let pending_tx2 = provider_fees
+    let pending_tx2 = tester_fees
         .tx()
         .with_rich_from(2)
         .with_max_fee_per_gas(150_000_000)
         .register()
         .await?;
 
-    provider_fees.anvil_mine(Some(1), None).await?;
+    tester_fees.l2_provider().anvil_mine(Some(1), None).await?;
 
-    let block = provider_fees.get_block(1.into()).await?.unwrap();
+    let block = tester_fees
+        .l2_provider()
+        .get_block(1.into())
+        .await?
+        .unwrap();
     let tx_hashes = block.transactions.as_hashes().unwrap();
     assert_eq!(&tx_hashes[0], pending_tx2.tx_hash());
     assert_eq!(&tx_hashes[1], pending_tx1.tx_hash());
@@ -587,14 +600,14 @@ async fn pool_txs_order_fees() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn transactions_have_index() -> anyhow::Result<()> {
-    let provider = TestingProviderBuilder::default()
+    let tester = AnvilZksyncTesterBuilder::default()
         .with_node_fn(&|node| node.no_mine())
         .build()
         .await?;
-    let tx1 = provider.tx().with_rich_from(0).register().await?;
-    let tx2 = provider.tx().with_rich_from(1).register().await?;
+    let tx1 = tester.tx().with_rich_from(0).register().await?;
+    let tx2 = tester.tx().with_rich_from(1).register().await?;
 
-    provider.anvil_mine(Some(1), None).await?;
+    tester.l2_provider().anvil_mine(Some(1), None).await?;
 
     let receipt1 = tx1.wait_until_finalized().await?;
     let receipt2 = tx2.wait_until_finalized().await?;
@@ -610,7 +623,7 @@ async fn dump_state_on_run() -> anyhow::Result<()> {
     let dump_path = temp_dir.path().join("state_dump.json");
 
     let dump_path_clone = dump_path.clone();
-    let provider = TestingProviderBuilder::default()
+    let tester = AnvilZksyncTesterBuilder::default()
         .with_node_fn(&|node| {
             node.path(get_node_binary_path())
                 .arg("--state-interval")
@@ -621,12 +634,12 @@ async fn dump_state_on_run() -> anyhow::Result<()> {
         .build()
         .await?;
 
-    let receipt = provider.tx().finalize().await?;
+    let receipt = tester.tx().finalize().await?;
     let tx_hash = receipt.transaction_hash().to_string();
 
     tokio::time::sleep(Duration::from_secs(2)).await;
 
-    drop(provider);
+    drop(tester);
 
     assert!(
         dump_path.exists(),
@@ -676,7 +689,7 @@ async fn dump_state_on_fork() -> anyhow::Result<()> {
     let dump_path = temp_dir.path().join("state_dump_fork.json");
 
     let dump_path_clone = dump_path.clone();
-    let provider = TestingProviderBuilder::default()
+    let tester = AnvilZksyncTesterBuilder::default()
         .with_node_fn(&|node| {
             node.path(get_node_binary_path())
                 .arg("--state-interval")
@@ -688,12 +701,12 @@ async fn dump_state_on_fork() -> anyhow::Result<()> {
         .build()
         .await?;
 
-    let receipt = provider.tx().finalize().await?;
+    let receipt = tester.tx().finalize().await?;
     let tx_hash = receipt.transaction_hash().to_string();
 
     tokio::time::sleep(Duration::from_secs(2)).await;
 
-    drop(provider);
+    drop(tester);
 
     assert!(
         dump_path.exists(),
@@ -738,14 +751,11 @@ async fn dump_state_on_fork() -> anyhow::Result<()> {
 async fn load_state_on_run() -> anyhow::Result<()> {
     let temp_dir = TempDir::new("load-state-test").expect("failed creating temporary dir");
     let dump_path = temp_dir.path().join("load_state_run.json");
-    let provider = TestingProviderBuilder::default().build().await?;
-    let receipts = [
-        provider.tx().finalize().await?,
-        provider.tx().finalize().await?,
-    ];
-    let blocks = provider.get_blocks_by_receipts(&receipts).await?;
-    let state_bytes = provider.anvil_dump_state().await?;
-    drop(provider);
+    let tester = AnvilZksyncTesterBuilder::default().build().await?;
+    let receipts = [tester.tx().finalize().await?, tester.tx().finalize().await?];
+    let blocks = tester.get_blocks_by_receipts(&receipts).await?;
+    let state_bytes = tester.l2_provider().anvil_dump_state().await?;
+    drop(tester);
 
     let mut decoder = GzDecoder::new(&state_bytes.0[..]);
     let mut json_str = String::new();
@@ -754,7 +764,7 @@ async fn load_state_on_run() -> anyhow::Result<()> {
     write_json_file(&dump_path, &state)?;
 
     let dump_path_clone = dump_path.clone();
-    let new_provider = TestingProviderBuilder::default()
+    let new_provider = AnvilZksyncTesterBuilder::default()
         .with_node_fn(&|node| {
             node.path(get_node_binary_path())
                 .arg("--state-interval")
@@ -791,14 +801,11 @@ async fn load_state_on_run() -> anyhow::Result<()> {
 async fn load_state_on_fork() -> anyhow::Result<()> {
     let temp_dir = TempDir::new("load-state-fork-test").expect("failed creating temporary dir");
     let dump_path = temp_dir.path().join("load_state_fork.json");
-    let provider = TestingProviderBuilder::default().build().await?;
-    let receipts = [
-        provider.tx().finalize().await?,
-        provider.tx().finalize().await?,
-    ];
-    let blocks = provider.get_blocks_by_receipts(&receipts).await?;
-    let state_bytes = provider.anvil_dump_state().await?;
-    drop(provider);
+    let tester = AnvilZksyncTesterBuilder::default().build().await?;
+    let receipts = [tester.tx().finalize().await?, tester.tx().finalize().await?];
+    let blocks = tester.get_blocks_by_receipts(&receipts).await?;
+    let state_bytes = tester.l2_provider().anvil_dump_state().await?;
+    drop(tester);
 
     let mut decoder = GzDecoder::new(&state_bytes.0[..]);
     let mut json_str = String::new();
@@ -807,7 +814,7 @@ async fn load_state_on_fork() -> anyhow::Result<()> {
     write_json_file(&dump_path, &state)?;
 
     let dump_path_clone = dump_path.clone();
-    let new_provider = TestingProviderBuilder::default()
+    let new_provider = AnvilZksyncTesterBuilder::default()
         .with_node_fn(&|node| {
             node.path(get_node_binary_path())
                 .arg("--state-interval")


### PR DESCRIPTION
# What :computer: 
This PR:
* Migrates anvil-zksync + e2e tests to alloy 0.12.x
* Makes e2e initialization a bit cleaner by implementing builder pattern for `TestingProvider`
* Renames `TestingProvider` to `AnvilZksyncTester` and makes it hold both `l1_provider` (optional) and `l2_provider`

# Why :hand:
Keeping up with alloy development + a bunch of long overdue refactorings