### PR TITLE
chore: improved counter increment syntax for clarity

### DIFF
--- a/scripts/execute-e2e-tests.sh
+++ b/scripts/execute-e2e-tests.sh
@@ -24,7 +24,7 @@ while [ $COUNTER -lt $MAX_RETRIES ]; do
         break
     else
         echo "Node not ready, retrying in 1 second..."
-        let COUNTER=COUNTER+1
+        ((COUNTER++))
         sleep 1
     fi
 done


### PR DESCRIPTION
# What :computer:  
I updated the counter increment in the script to use the more common and readable `((COUNTER++))` syntax instead of `let COUNTER=COUNTER+1`.

# Why :hand:  
The new syntax is more concise, easier to read, and follows standard Bash practices. It improves the clarity of the code.

# Evidence :camera:  
Before:
```bash
let COUNTER=COUNTER+1
```

After:
```bash
((COUNTER++))
```