### PR TITLE
feat: support replay of L1 and upgrade transactions

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -353,12 +353,9 @@ async fn start_program() -> Result<(), AnvilZksyncError> {
     }
 
     if !transactions_to_replay.is_empty() {
-        node.apply_txs(
-            transactions_to_replay.into_iter().map(Into::into).collect(),
-            config.max_transactions,
-        )
-        .await
-        .map_err(to_domain)?;
+        node.replay_txs(transactions_to_replay)
+            .await
+            .map_err(to_domain)?;
 
         // If we are in replay mode, we don't start the server
         return Ok(());

--- a/crates/core/src/node/in_memory_ext.rs
+++ b/crates/core/src/node/in_memory_ext.rs
@@ -399,7 +399,7 @@ mod tests {
     use crate::testing::TransactionBuilder;
     use std::str::FromStr;
     use zksync_multivm::interface::storage::ReadStorage;
-    use zksync_types::{api, L1BatchNumber};
+    use zksync_types::{api, L1BatchNumber, Transaction};
     use zksync_types::{h256_to_u256, L2ChainId, H256};
 
     #[tokio::test]
@@ -564,11 +564,12 @@ mod tests {
             .unwrap();
         assert!(result);
 
-        // construct a tx
-        let tx = TransactionBuilder::new().impersonate(to_impersonate);
+        // construct a random tx each time to avoid hash collision
+        let generate_tx =
+            || Transaction::from(TransactionBuilder::new().impersonate(to_impersonate));
 
         // try to execute the tx- should fail without signature
-        assert!(node.apply_txs(vec![tx.clone().into()], 1).await.is_err());
+        assert!(node.apply_txs([generate_tx()]).await.is_err());
 
         // impersonate the account
         let result = node
@@ -585,7 +586,7 @@ mod tests {
         assert!(!result);
 
         // execution should now succeed
-        assert!(node.apply_txs(vec![tx.clone().into()], 1).await.is_ok());
+        assert!(node.apply_txs([generate_tx()]).await.is_ok());
 
         // stop impersonating the account
         let result = node
@@ -602,7 +603,7 @@ mod tests {
         assert!(!result);
 
         // execution should now fail again
-        assert!(node.apply_txs(vec![tx.into()], 1).await.is_err());
+        assert!(node.apply_txs([generate_tx()]).await.is_err());
     }
 
     #[tokio::test]

--- a/crates/core/src/node/inner/fork.rs
+++ b/crates/core/src/node/inner/fork.rs
@@ -16,11 +16,11 @@ use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use tracing::Instrument;
 use url::Url;
 use zksync_types::fee_model::FeeParams;
-use zksync_types::l2::L2Tx;
 use zksync_types::url::SensitiveUrl;
 use zksync_types::web3::Index;
 use zksync_types::{
-    api, Address, L1BatchNumber, L2BlockNumber, L2ChainId, ProtocolVersionId, H256, U256,
+    api, Address, L1BatchNumber, L2BlockNumber, L2ChainId, ProtocolVersionId, Transaction, H256,
+    U256,
 };
 use zksync_web3_decl::client::{DynClient, L2};
 use zksync_web3_decl::error::Web3Error;
@@ -343,7 +343,7 @@ impl ForkClient {
     pub async fn at_before_tx(
         config: ForkConfig,
         tx_hash: H256,
-    ) -> anyhow::Result<(Self, Vec<L2Tx>)> {
+    ) -> anyhow::Result<(Self, Vec<Transaction>)> {
         let l2_client =
             zksync_web3_decl::client::Client::http(SensitiveUrl::from(config.url.clone()))?.build();
         let tx_details = l2_client
@@ -369,10 +369,7 @@ impl ForkClient {
         let mut earlier_txs = Vec::new();
         for tx in l2_client.get_raw_block_transactions(block_number).await? {
             let hash = tx.hash();
-            let l2_tx: L2Tx = tx
-                .try_into()
-                .map_err(|e| anyhow::anyhow!("Failed to convert to L2 transaction: {e}"))?;
-            earlier_txs.push(l2_tx);
+            earlier_txs.push(tx);
 
             if hash == tx_hash {
                 break;


### PR DESCRIPTION
# What :computer: 
There is no functional restriction on why we can't replay L1 txs (or even upgrade txs) from fork. This PR ensures this flow is supported.

# Why :hand:
Useful for debugging L1 transactions from testnet/mainnet