### PR TITLE
fix: allow wider `anvil` versions

### DIFF
--- a/crates/l1_sidecar/src/anvil.rs
+++ b/crates/l1_sidecar/src/anvil.rs
@@ -94,12 +94,12 @@ async fn ensure_anvil_1_x_x() -> anyhow::Result<()> {
         })?;
     let version = Version::parse(version)?;
     tracing::debug!(%version, "detected installed anvil version");
-    // Allow any version above `1.0.0-rc` (including `1.0.0-stable`)
-    if version > Version::parse("1.0.0-rc")? {
+    // Allow any non-0.x version (including `1.0.0-stable`, `1.0.0-nightly` and other pre-releases)
+    if version.major >= 1 {
         Ok(())
     } else {
         Err(anyhow::anyhow!(
-            "unsupported `anvil` version ({}), please upgrade to >1.0.0-rc",
+            "unsupported `anvil` version ({}), please upgrade to >=1.0.0",
             version
         ))
     }


### PR DESCRIPTION
# What :computer: 
Noticed that we do not allow `anvil 1.0.0-nightly` so I relaxed constraints

# Why :hand:
Current nightly anvil releases still use `1.0.0` as the base (which is weird given that 1.0.0 has been released already)
