### PR TITLE
fix: usize to u32 conversion for pubdata limit

### DIFF
--- a/crates/core/src/node/inner/in_memory_inner.rs
+++ b/crates/core/src/node/inner/in_memory_inner.rs
@@ -533,7 +533,7 @@ impl InMemoryNodeInner {
                 self.system_contracts.use_zkos,
             );
 
-            if result.statistics.pubdata_published > MAX_VM_PUBDATA_PER_BATCH.try_into().unwrap() {
+            if result.statistics.pubdata_published > (MAX_VM_PUBDATA_PER_BATCH as u32) {
                 return Err(Web3Error::SubmitTransactionError(
                     "exceeds limit for published pubdata".into(),
                     Default::default(),


### PR DESCRIPTION
# What :computer: 
* Convert MAX_VM_PUBDATA_PER_BATCH (761,856) from usize to u32 using `as` cast, which is safe since the constant is statically computed as 6 blobs * (31 * 4096) bytes and well within u32 bounds.

# Why :hand:
* `deranged` dependency update from 0.4.0 to 0.4.1 from Upstream Foundry isn't possible without this conversion for the type infer. 

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
