### PR TITLE
feat: warn of transactions to non-assigned addresses

### DIFF
--- a/crates/core/src/node/eth.rs
+++ b/crates/core/src/node/eth.rs
@@ -1,8 +1,8 @@
-use std::collections::HashSet;
 use crate::formatter::ExecutionErrorReport;
 use crate::node::error::{ToHaltError, ToRevertReason};
 use anvil_zksync_common::{sh_err, sh_println, sh_warn};
 use anyhow::Context as _;
+use std::collections::HashSet;
 use zksync_error::anvil_zksync::{halt::HaltError, revert::RevertError};
 use zksync_multivm::interface::ExecutionResult;
 use zksync_multivm::vm_latest::constants::ETH_CALL_GAS_LIMIT;

--- a/crates/core/src/node/eth.rs
+++ b/crates/core/src/node/eth.rs
@@ -1,8 +1,7 @@
 use std::collections::HashSet;
-
 use crate::formatter::ExecutionErrorReport;
 use crate::node::error::{ToHaltError, ToRevertReason};
-use anvil_zksync_common::{sh_err, sh_println};
+use anvil_zksync_common::{sh_err, sh_println, sh_warn};
 use anyhow::Context as _;
 use zksync_error::anvil_zksync::{halt::HaltError, revert::RevertError};
 use zksync_multivm::interface::ExecutionResult;
@@ -42,6 +41,17 @@ impl InMemoryNode {
             MAX_TX_SIZE,
             self.system_contracts.allow_no_target(),
         )?;
+
+        // Warn if target address has no code
+        if let Some(to_address) = tx.execute.contract_address {
+            let code_key = get_code_key(&to_address);
+            if self.storage.read_value_alt(&code_key).await?.is_zero() {
+                sh_warn!(
+                    "Read only call to address {to_address}, which is not associated with any contract."
+                )
+            }
+        }
+
         tx.common_data.fee.gas_limit = ETH_CALL_GAS_LIMIT.into();
         let call_result = self
             .run_l2_call(tx.clone(), system_contracts)

--- a/crates/core/src/node/inner/vm_runner.rs
+++ b/crates/core/src/node/inner/vm_runner.rs
@@ -162,7 +162,7 @@ impl VmRunner {
             // If bytecode hash is zero, there's no code at this address
             if bytecode_hash == H256::zero() {
                 sh_warn!(
-                    "Transaction {} was sent to address {to_address} that is not associated with a contract",
+                    "Transaction {} was sent to address {to_address}, which is not associated with any contract.",
                     tx.hash()
                 );
             }

--- a/crates/core/src/node/inner/vm_runner.rs
+++ b/crates/core/src/node/inner/vm_runner.rs
@@ -153,11 +153,13 @@ impl VmRunner {
         config: &TestNodeConfig,
         fee_input_provider: &TestNodeFeeInputProvider,
     ) -> anyhow::Result<BatchTransactionExecutionResult> {
-
         // Check if target address has code before executing the transaction
         if let Some(to_address) = tx.recipient_account() {
             let code_key = zksync_types::get_code_key(&to_address);
-            let bytecode_hash = zksync_multivm::interface::storage::ReadStorage::read_value(&mut self.fork_storage, &code_key);
+            let bytecode_hash = zksync_multivm::interface::storage::ReadStorage::read_value(
+                &mut self.fork_storage,
+                &code_key,
+            );
 
             // If bytecode hash is zero, there's no code at this address
             if bytecode_hash == H256::zero() {

--- a/crates/core/src/node/inner/vm_runner.rs
+++ b/crates/core/src/node/inner/vm_runner.rs
@@ -162,7 +162,7 @@ impl VmRunner {
             );
 
             // If bytecode hash is zero, there's no code at this address
-            if bytecode_hash == H256::zero() {
+            if bytecode_hash.is_zero() {
                 sh_warn!(
                     "Transaction {} was sent to address {to_address}, which is not associated with any contract.",
                     tx.hash()

--- a/crates/core/src/node/inner/vm_runner.rs
+++ b/crates/core/src/node/inner/vm_runner.rs
@@ -15,7 +15,7 @@ use crate::node::{
 use crate::system_contracts::SystemContracts;
 use crate::utils::create_debug_output;
 use anvil_zksync_common::shell::get_shell;
-use anvil_zksync_common::{sh_eprintln, sh_err, sh_println};
+use anvil_zksync_common::{sh_eprintln, sh_err, sh_println, sh_warn};
 use anvil_zksync_config::TestNodeConfig;
 use anvil_zksync_console::console_log::ConsoleLogHandler;
 use anvil_zksync_traces::decode::CallTraceDecoderBuilder;
@@ -153,6 +153,21 @@ impl VmRunner {
         config: &TestNodeConfig,
         fee_input_provider: &TestNodeFeeInputProvider,
     ) -> anyhow::Result<BatchTransactionExecutionResult> {
+
+        // Check if target address has code before executing the transaction
+        if let Some(to_address) = tx.recipient_account() {
+            let code_key = zksync_types::get_code_key(&to_address);
+            let bytecode_hash = zksync_multivm::interface::storage::ReadStorage::read_value(&mut self.fork_storage, &code_key);
+
+            // If bytecode hash is zero, there's no code at this address
+            if bytecode_hash == H256::zero() {
+                sh_warn!(
+                    "Transaction {} was sent to address {to_address} that is not associated with a contract",
+                    tx.hash()
+                );
+            }
+        }
+
         let BatchTransactionExecutionResult {
             tx_result,
             compression_result,

--- a/e2e-tests-rust/src/contracts/mod.rs
+++ b/e2e-tests-rust/src/contracts/mod.rs
@@ -248,16 +248,7 @@ impl<P: Provider<Ethereum>> L1Nullifier<P> {
             .logs()
             .iter()
             .find_map(|log| {
-                if log.address() != L1_MESSENGER_ADDRESS {
-                    return None;
-                }
-                if let Ok(l1_message_sent) =
-                    log.log_decode::<private::IL1Messenger::L1MessageSent>()
-                {
-                    Some(l1_message_sent)
-                } else {
-                    None
-                }
+                    log.log_decode::<private::IL1Messenger::L1MessageSent>().ok()
             })
             .expect("no `L1MessageSent` events found in withdrawal receipt");
         let (l2_to_l1_log_index, _) = withdrawal_l2_receipt

--- a/e2e-tests-rust/src/contracts/mod.rs
+++ b/e2e-tests-rust/src/contracts/mod.rs
@@ -248,7 +248,8 @@ impl<P: Provider<Ethereum>> L1Nullifier<P> {
             .logs()
             .iter()
             .find_map(|log| {
-                    log.log_decode::<private::IL1Messenger::L1MessageSent>().ok()
+                log.log_decode::<private::IL1Messenger::L1MessageSent>()
+                    .ok()
             })
             .expect("no `L1MessageSent` events found in withdrawal receipt");
         let (l2_to_l1_log_index, _) = withdrawal_l2_receipt


### PR DESCRIPTION
# What :computer: 
* Transactions to addresses that are not assigned to contracts produce warnings
* Eth calls to addresses that are not assigned to contracts produce warnings 

# Why :hand:
* Better diagnostics

# Evidence :camera:
## Transactions

```
cast send 0x1111111111111111111111111111111111111111 "transfer(address,uint256)" 0x70997970C51812dc3A010C7d01b50e0d17dc79C8 5000 --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80  --rpc-url http://localhost:8011 --chain 260
```
Response: 
```
Warning: Transaction 0xaca6…f4ec was sent to address 0x1111…1111, which is not associated with any contract.

```
## Eth Calls
```
cast call 0x1111111111111111111111111111111111111111 "method(address,uint256)(uint256)" "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266" 1 --rpc-url http://localhost:8011
```

Response:
```
Warning: Read only call to address 0x1111…1111, which is not associated with any contract.
```
