### PR TITLE
chore: resolve new `rustc 1.86.0` warnings + fix cargo deny

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4332,7 +4332,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -6908,9 +6908,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.41.1"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",
@@ -6927,9 +6927,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/e2e-tests-rust/src/contracts/mod.rs
+++ b/e2e-tests-rust/src/contracts/mod.rs
@@ -251,13 +251,8 @@ impl<P: Provider<Ethereum>> L1Nullifier<P> {
                 if log.address() != L1_MESSENGER_ADDRESS {
                     return None;
                 }
-                if let Ok(l1_message_sent) =
-                    log.log_decode::<private::IL1Messenger::L1MessageSent>()
-                {
-                    Some(l1_message_sent)
-                } else {
-                    None
-                }
+                log.log_decode::<private::IL1Messenger::L1MessageSent>()
+                    .ok()
             })
             .expect("no `L1MessageSent` events found in withdrawal receipt");
         let (l2_to_l1_log_index, _) = withdrawal_l2_receipt


### PR DESCRIPTION
# What :computer: 
Fix new compilation warnings and upgrade tokio to resolve cargo deny error

# Why :hand:
CI is red
