### PR TITLE
chore: upgrade zksync-era to v27.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2020,14 +2020,14 @@ dependencies = [
 
 [[package]]
 name = "circuit_sequencer_api"
-version = "0.151.3"
+version = "0.151.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "359172aea9566a0e428eb4b351e3f30ebb5ccf4e5dfadde35fd1e5813dc1114c"
+checksum = "e7a52138983ea94b367d689fc6183ad60a769d6c7ce8041c5120cb5074486ea2"
 dependencies = [
  "derivative",
  "rayon",
  "serde",
- "zk_evm 0.151.3",
+ "zk_evm 0.151.5",
  "zksync_bellman",
 ]
 
@@ -5210,9 +5210,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus-client"
-version = "0.22.3"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504ee9ff529add891127c4827eb481bd69dc0ebc72e9a682e187db4caa60c3ca"
+checksum = "cf41c1a7c32ed72abe5082fb19505b969095c12da9f5732a4bc9878757fd087c"
 dependencies = [
  "dtoa",
  "itoa",
@@ -7483,8 +7483,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "vise"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ade36f3548b1524396f4de7b36f4f210c8a01dfab568eb2bff466af64eb6e5"
+source = "git+https://github.com/matter-labs/vise.git?rev=51669f42f60c50b3a521662a4ecd71212a303299#51669f42f60c50b3a521662a4ecd71212a303299"
 dependencies = [
  "compile-fmt",
  "ctor",
@@ -7497,8 +7496,7 @@ dependencies = [
 [[package]]
 name = "vise-macros"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a511871dc5de990a3b2a0e715facfbc5da848c0c0395597a1415029fb7c250a"
+source = "git+https://github.com/matter-labs/vise.git?rev=51669f42f60c50b3a521662a4ecd71212a303299#51669f42f60c50b3a521662a4ecd71212a303299"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8181,9 +8179,9 @@ dependencies = [
 
 [[package]]
 name = "zk_evm"
-version = "0.151.3"
+version = "0.151.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b255c641faf40e20be07d8f3842ddd00793b597c0bd74c91b7a9a34b5a94308"
+checksum = "4587cac12bc0a037b29b5c12fe107f06d1f2d1f62f64ebed6ce4c6bf5290c58a"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -8191,7 +8189,7 @@ dependencies = [
  "serde",
  "serde_json",
  "static_assertions",
- "zk_evm_abstractions 0.151.4",
+ "zk_evm_abstractions 0.151.5",
 ]
 
 [[package]]
@@ -8235,15 +8233,15 @@ dependencies = [
 
 [[package]]
 name = "zk_evm_abstractions"
-version = "0.151.4"
+version = "0.151.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138f54be34b1cc6742c43b6bdde876d7a03cbdabc033592d9dcf42b87027b75d"
+checksum = "c91ea662a71ec92c72f5d1628486d1e68c1a50fd13e07ef57dcd2a6d4161b68f"
 dependencies = [
  "anyhow",
  "num_enum 0.6.1",
  "serde",
  "static_assertions",
- "zkevm_opcode_defs 0.151.4",
+ "zkevm_opcode_defs 0.151.5",
 ]
 
 [[package]]
@@ -8307,9 +8305,9 @@ dependencies = [
 
 [[package]]
 name = "zkevm_opcode_defs"
-version = "0.151.4"
+version = "0.151.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b423f91a70a87a6c7658da01398ebff72fd4ac36f555f745488097ebcc7f1159"
+checksum = "fb02c38d4486568f3ce4aed592a26139aa942eb3cef973a78cfc053cddc54d06"
 dependencies = [
  "bitflags 2.6.0",
  "blake2",
@@ -8373,8 +8371,8 @@ dependencies = [
 
 [[package]]
 name = "zksync_basic_types"
-version = "27.0.0-non-semver-compat"
-source = "git+https://github.com/matter-labs/zksync-era?rev=core-v27.0.0#3e9fc0a5f6abffdae994e4f22ab21eac95c7ac08"
+version = "27.2.0-non-semver-compat"
+source = "git+https://github.com/matter-labs/zksync-era?rev=core-v27.2.0#0d2bb67af441758690c195380d6f6d137967f19a"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8418,9 +8416,9 @@ dependencies = [
 
 [[package]]
 name = "zksync_concurrency"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cec98400a9e8ba02bfd029eacfe7d6fb7b85b8ef00de59d6bb119d29cc9f7442"
+checksum = "a437d604f41b4fd587107e79bcbcb36f669f4b4e4c29e42ae2f26871a8c99bb7"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -8437,8 +8435,8 @@ dependencies = [
 
 [[package]]
 name = "zksync_config"
-version = "27.0.0-non-semver-compat"
-source = "git+https://github.com/matter-labs/zksync-era?rev=core-v27.0.0#3e9fc0a5f6abffdae994e4f22ab21eac95c7ac08"
+version = "27.2.0-non-semver-compat"
+source = "git+https://github.com/matter-labs/zksync-era?rev=core-v27.2.0#0d2bb67af441758690c195380d6f6d137967f19a"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -8452,9 +8450,9 @@ dependencies = [
 
 [[package]]
 name = "zksync_consensus_utils"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f9fa69ef68e6a1955a1d7b33077103fb6d106b560fec0d599c6de268f5be03"
+checksum = "ed85ed3bccb73a24f3cade637db54d3da504e250b673a47c8179bd64fcb68ea8"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -8464,8 +8462,8 @@ dependencies = [
 
 [[package]]
 name = "zksync_contracts"
-version = "27.0.0-non-semver-compat"
-source = "git+https://github.com/matter-labs/zksync-era?rev=core-v27.0.0#3e9fc0a5f6abffdae994e4f22ab21eac95c7ac08"
+version = "27.2.0-non-semver-compat"
+source = "git+https://github.com/matter-labs/zksync-era?rev=core-v27.2.0#0d2bb67af441758690c195380d6f6d137967f19a"
 dependencies = [
  "envy",
  "hex",
@@ -8478,8 +8476,8 @@ dependencies = [
 
 [[package]]
 name = "zksync_crypto_primitives"
-version = "27.0.0-non-semver-compat"
-source = "git+https://github.com/matter-labs/zksync-era?rev=core-v27.0.0#3e9fc0a5f6abffdae994e4f22ab21eac95c7ac08"
+version = "27.2.0-non-semver-compat"
+source = "git+https://github.com/matter-labs/zksync-era?rev=core-v27.2.0#0d2bb67af441758690c195380d6f6d137967f19a"
 dependencies = [
  "anyhow",
  "blake2",
@@ -8495,8 +8493,8 @@ dependencies = [
 
 [[package]]
 name = "zksync_da_client"
-version = "27.0.0-non-semver-compat"
-source = "git+https://github.com/matter-labs/zksync-era?rev=core-v27.0.0#3e9fc0a5f6abffdae994e4f22ab21eac95c7ac08"
+version = "27.2.0-non-semver-compat"
+source = "git+https://github.com/matter-labs/zksync-era?rev=core-v27.2.0#0d2bb67af441758690c195380d6f6d137967f19a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8546,8 +8544,8 @@ dependencies = [
 
 [[package]]
 name = "zksync_mini_merkle_tree"
-version = "27.0.0-non-semver-compat"
-source = "git+https://github.com/matter-labs/zksync-era?rev=core-v27.0.0#3e9fc0a5f6abffdae994e4f22ab21eac95c7ac08"
+version = "27.2.0-non-semver-compat"
+source = "git+https://github.com/matter-labs/zksync-era?rev=core-v27.2.0#0d2bb67af441758690c195380d6f6d137967f19a"
 dependencies = [
  "once_cell",
  "zksync_basic_types",
@@ -8556,8 +8554,8 @@ dependencies = [
 
 [[package]]
 name = "zksync_multivm"
-version = "27.0.0-non-semver-compat"
-source = "git+https://github.com/matter-labs/zksync-era?rev=core-v27.0.0#3e9fc0a5f6abffdae994e4f22ab21eac95c7ac08"
+version = "27.2.0-non-semver-compat"
+source = "git+https://github.com/matter-labs/zksync-era?rev=core-v27.2.0#0d2bb67af441758690c195380d6f6d137967f19a"
 dependencies = [
  "anyhow",
  "circuit_sequencer_api",
@@ -8572,7 +8570,7 @@ dependencies = [
  "zk_evm 0.133.0",
  "zk_evm 0.140.0",
  "zk_evm 0.141.0",
- "zk_evm 0.151.3",
+ "zk_evm 0.151.5",
  "zksync_contracts",
  "zksync_mini_merkle_tree",
  "zksync_system_constants",
@@ -8596,8 +8594,8 @@ dependencies = [
 
 [[package]]
 name = "zksync_system_constants"
-version = "27.0.0-non-semver-compat"
-source = "git+https://github.com/matter-labs/zksync-era?rev=core-v27.0.0#3e9fc0a5f6abffdae994e4f22ab21eac95c7ac08"
+version = "27.2.0-non-semver-compat"
+source = "git+https://github.com/matter-labs/zksync-era?rev=core-v27.2.0#0d2bb67af441758690c195380d6f6d137967f19a"
 dependencies = [
  "once_cell",
  "zksync_basic_types",
@@ -8622,8 +8620,8 @@ dependencies = [
 
 [[package]]
 name = "zksync_types"
-version = "27.0.0-non-semver-compat"
-source = "git+https://github.com/matter-labs/zksync-era?rev=core-v27.0.0#3e9fc0a5f6abffdae994e4f22ab21eac95c7ac08"
+version = "27.2.0-non-semver-compat"
+source = "git+https://github.com/matter-labs/zksync-era?rev=core-v27.2.0#0d2bb67af441758690c195380d6f6d137967f19a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8649,8 +8647,8 @@ dependencies = [
 
 [[package]]
 name = "zksync_utils"
-version = "27.0.0-non-semver-compat"
-source = "git+https://github.com/matter-labs/zksync-era?rev=core-v27.0.0#3e9fc0a5f6abffdae994e4f22ab21eac95c7ac08"
+version = "27.2.0-non-semver-compat"
+source = "git+https://github.com/matter-labs/zksync-era?rev=core-v27.2.0#0d2bb67af441758690c195380d6f6d137967f19a"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -8682,8 +8680,8 @@ dependencies = [
 
 [[package]]
 name = "zksync_vm_interface"
-version = "27.0.0-non-semver-compat"
-source = "git+https://github.com/matter-labs/zksync-era?rev=core-v27.0.0#3e9fc0a5f6abffdae994e4f22ab21eac95c7ac08"
+version = "27.2.0-non-semver-compat"
+source = "git+https://github.com/matter-labs/zksync-era?rev=core-v27.2.0#0d2bb67af441758690c195380d6f6d137967f19a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8699,8 +8697,8 @@ dependencies = [
 
 [[package]]
 name = "zksync_web3_decl"
-version = "27.0.0-non-semver-compat"
-source = "git+https://github.com/matter-labs/zksync-era?rev=core-v27.0.0#3e9fc0a5f6abffdae994e4f22ab21eac95c7ac08"
+version = "27.2.0-non-semver-compat"
+source = "git+https://github.com/matter-labs/zksync-era?rev=core-v27.2.0#0d2bb67af441758690c195380d6f6d137967f19a"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,12 +35,12 @@ categories = ["cryptography"]
 #########################
 # ZKsync dependencies  #
 #########################
-zksync_mini_merkle_tree = { git = "https://github.com/matter-labs/zksync-era", rev = "core-v27.0.0" }
-zksync_multivm = { git = "https://github.com/matter-labs/zksync-era", rev = "core-v27.0.0" }
-zksync_contracts = { git = "https://github.com/matter-labs/zksync-era", rev = "core-v27.0.0" }
-zksync_types = { git = "https://github.com/matter-labs/zksync-era", rev = "core-v27.0.0" }
-zksync_vm_interface = { git = "https://github.com/matter-labs/zksync-era", rev = "core-v27.0.0" }
-zksync_web3_decl = { git = "https://github.com/matter-labs/zksync-era", rev = "core-v27.0.0" }
+zksync_mini_merkle_tree = { git = "https://github.com/matter-labs/zksync-era", rev = "core-v27.2.0" }
+zksync_multivm = { git = "https://github.com/matter-labs/zksync-era", rev = "core-v27.2.0" }
+zksync_contracts = { git = "https://github.com/matter-labs/zksync-era", rev = "core-v27.2.0" }
+zksync_types = { git = "https://github.com/matter-labs/zksync-era", rev = "core-v27.2.0" }
+zksync_vm_interface = { git = "https://github.com/matter-labs/zksync-era", rev = "core-v27.2.0" }
+zksync_web3_decl = { git = "https://github.com/matter-labs/zksync-era", rev = "core-v27.2.0" }
 zksync_telemetry = { git = "https://github.com/matter-labs/zksync-telemetry.git", rev = "f6d8618d870a09467ff24ea32ef57e01af8f311e" }
 zksync-error-codegen = { git = "https://github.com/matter-labs/zksync-error", rev = "76e8e471b048461d2754092fa159c87a47db5972", default-features = false }
 zksync-error-description = { git = "https://github.com/matter-labs/zksync-error", rev = "76e8e471b048461d2754092fa159c87a47db5972" }
@@ -121,3 +121,6 @@ anvil_zksync_traces = { path = "crates/traces" }
 
 # macros
 derive_more = { version = "1.0", features = ["full"] }
+
+[patch.crates-io]
+vise = { git = "https://github.com/matter-labs/vise.git", rev = "51669f42f60c50b3a521662a4ecd71212a303299" }

--- a/SUPPORTED_APIS.md
+++ b/SUPPORTED_APIS.md
@@ -172,6 +172,7 @@ The `status` options are:
 | [`ZKS`](#zks-namespace) | [`zks_L1ChainId`](#zks_l1chainid) | `SUPPORTED` | Returns the chain id of the underlying L1 |
 | `ZKS` | `zks_sendRawTransactionWithDetailedOutput` | `NOT IMPLEMENTED` | Executes a transaction with detailed output |
 | `ZKS` | `zks_getTimestampAsserter` | `NOT IMPLEMENTED` | Returns an address of timestamp asserter contract |
+| `ZKS` | `zks_getL2Multicall3` | `NOT IMPLEMENTED` | Returns the address of Multicall3 contract  |
 
 ## `CONFIG NAMESPACE`
 

--- a/crates/api_server/src/error.rs
+++ b/crates/api_server/src/error.rs
@@ -65,6 +65,7 @@ pub fn into_jsrpc_error(err: Web3Error) -> ErrorObjectOwned {
         Web3Error::SubmitTransactionError(_, _) | Web3Error::SerializationError(_) => {
             ErrorCode::ServerError(3).code()
         }
+        Web3Error::ServerShuttingDown => ErrorCode::ServerIsBusy.code(),
     };
     let message = match &err {
         Web3Error::SubmitTransactionError(_, _) => err.to_string(),

--- a/crates/api_server/src/impls/zks.rs
+++ b/crates/api_server/src/impls/zks.rs
@@ -65,7 +65,7 @@ impl ZksNamespaceServer for ZksNamespace {
         ))
     }
 
-    async fn get_main_contract(&self) -> RpcResult<Address> {
+    async fn get_main_l1_contract(&self) -> RpcResult<Address> {
         Err(RpcError::Unsupported.into())
     }
 
@@ -241,6 +241,10 @@ impl ZksNamespaceServer for ZksNamespace {
     }
 
     async fn get_timestamp_asserter(&self) -> RpcResult<Option<Address>> {
+        Err(RpcError::Unsupported.into())
+    }
+
+    async fn get_l2_multicall3(&self) -> RpcResult<Option<Address>> {
         Err(RpcError::Unsupported.into())
     }
 }

--- a/crates/zksync_error/src/error/definitions.rs
+++ b/crates/zksync_error/src/error/definitions.rs
@@ -48,7 +48,7 @@ pub enum AnvilEnvironment {
     #[doc = ""]
     #[doc = "The host and port used by anvil-zksync are also displayed when you start anvil-zksync:"]
     #[doc = ""]
-    #[doc = "```text"]
+    #[doc = "```"]
     #[doc = "========================================"]
     #[doc = "Listening on 0.0.0.0:8011"]
     #[doc = "========================================"]

--- a/e2e-tests-rust/Cargo.lock
+++ b/e2e-tests-rust/Cargo.lock
@@ -2124,14 +2124,14 @@ dependencies = [
 
 [[package]]
 name = "circuit_sequencer_api"
-version = "0.151.3"
+version = "0.151.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "359172aea9566a0e428eb4b351e3f30ebb5ccf4e5dfadde35fd1e5813dc1114c"
+checksum = "e7a52138983ea94b367d689fc6183ad60a769d6c7ce8041c5120cb5074486ea2"
 dependencies = [
  "derivative",
  "rayon",
  "serde",
- "zk_evm 0.151.3",
+ "zk_evm 0.151.5",
  "zksync_bellman",
 ]
 
@@ -5211,9 +5211,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus-client"
-version = "0.22.3"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504ee9ff529add891127c4827eb481bd69dc0ebc72e9a682e187db4caa60c3ca"
+checksum = "cf41c1a7c32ed72abe5082fb19505b969095c12da9f5732a4bc9878757fd087c"
 dependencies = [
  "dtoa",
  "itoa",
@@ -7403,8 +7403,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "vise"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ade36f3548b1524396f4de7b36f4f210c8a01dfab568eb2bff466af64eb6e5"
+source = "git+https://github.com/matter-labs/vise.git?rev=51669f42f60c50b3a521662a4ecd71212a303299#51669f42f60c50b3a521662a4ecd71212a303299"
 dependencies = [
  "compile-fmt",
  "ctor",
@@ -7417,8 +7416,7 @@ dependencies = [
 [[package]]
 name = "vise-macros"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a511871dc5de990a3b2a0e715facfbc5da848c0c0395597a1415029fb7c250a"
+source = "git+https://github.com/matter-labs/vise.git?rev=51669f42f60c50b3a521662a4ecd71212a303299#51669f42f60c50b3a521662a4ecd71212a303299"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8064,9 +8062,9 @@ dependencies = [
 
 [[package]]
 name = "zk_evm"
-version = "0.151.3"
+version = "0.151.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b255c641faf40e20be07d8f3842ddd00793b597c0bd74c91b7a9a34b5a94308"
+checksum = "4587cac12bc0a037b29b5c12fe107f06d1f2d1f62f64ebed6ce4c6bf5290c58a"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -8074,7 +8072,7 @@ dependencies = [
  "serde",
  "serde_json",
  "static_assertions",
- "zk_evm_abstractions 0.151.4",
+ "zk_evm_abstractions 0.151.5",
 ]
 
 [[package]]
@@ -8118,15 +8116,15 @@ dependencies = [
 
 [[package]]
 name = "zk_evm_abstractions"
-version = "0.151.4"
+version = "0.151.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138f54be34b1cc6742c43b6bdde876d7a03cbdabc033592d9dcf42b87027b75d"
+checksum = "c91ea662a71ec92c72f5d1628486d1e68c1a50fd13e07ef57dcd2a6d4161b68f"
 dependencies = [
  "anyhow",
  "num_enum 0.6.1",
  "serde",
  "static_assertions",
- "zkevm_opcode_defs 0.151.4",
+ "zkevm_opcode_defs 0.151.5",
 ]
 
 [[package]]
@@ -8190,9 +8188,9 @@ dependencies = [
 
 [[package]]
 name = "zkevm_opcode_defs"
-version = "0.151.4"
+version = "0.151.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b423f91a70a87a6c7658da01398ebff72fd4ac36f555f745488097ebcc7f1159"
+checksum = "fb02c38d4486568f3ce4aed592a26139aa942eb3cef973a78cfc053cddc54d06"
 dependencies = [
  "bitflags 2.6.0",
  "blake2",
@@ -8256,8 +8254,8 @@ dependencies = [
 
 [[package]]
 name = "zksync_basic_types"
-version = "27.0.0-non-semver-compat"
-source = "git+https://github.com/matter-labs/zksync-era?rev=core-v27.0.0#3e9fc0a5f6abffdae994e4f22ab21eac95c7ac08"
+version = "27.2.0-non-semver-compat"
+source = "git+https://github.com/matter-labs/zksync-era?rev=core-v27.2.0#0d2bb67af441758690c195380d6f6d137967f19a"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8301,9 +8299,9 @@ dependencies = [
 
 [[package]]
 name = "zksync_concurrency"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cec98400a9e8ba02bfd029eacfe7d6fb7b85b8ef00de59d6bb119d29cc9f7442"
+checksum = "a437d604f41b4fd587107e79bcbcb36f669f4b4e4c29e42ae2f26871a8c99bb7"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -8320,8 +8318,8 @@ dependencies = [
 
 [[package]]
 name = "zksync_config"
-version = "27.0.0-non-semver-compat"
-source = "git+https://github.com/matter-labs/zksync-era?rev=core-v27.0.0#3e9fc0a5f6abffdae994e4f22ab21eac95c7ac08"
+version = "27.2.0-non-semver-compat"
+source = "git+https://github.com/matter-labs/zksync-era?rev=core-v27.2.0#0d2bb67af441758690c195380d6f6d137967f19a"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -8335,9 +8333,9 @@ dependencies = [
 
 [[package]]
 name = "zksync_consensus_utils"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f9fa69ef68e6a1955a1d7b33077103fb6d106b560fec0d599c6de268f5be03"
+checksum = "ed85ed3bccb73a24f3cade637db54d3da504e250b673a47c8179bd64fcb68ea8"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -8347,8 +8345,8 @@ dependencies = [
 
 [[package]]
 name = "zksync_contracts"
-version = "27.0.0-non-semver-compat"
-source = "git+https://github.com/matter-labs/zksync-era?rev=core-v27.0.0#3e9fc0a5f6abffdae994e4f22ab21eac95c7ac08"
+version = "27.2.0-non-semver-compat"
+source = "git+https://github.com/matter-labs/zksync-era?rev=core-v27.2.0#0d2bb67af441758690c195380d6f6d137967f19a"
 dependencies = [
  "envy",
  "hex",
@@ -8361,8 +8359,8 @@ dependencies = [
 
 [[package]]
 name = "zksync_crypto_primitives"
-version = "27.0.0-non-semver-compat"
-source = "git+https://github.com/matter-labs/zksync-era?rev=core-v27.0.0#3e9fc0a5f6abffdae994e4f22ab21eac95c7ac08"
+version = "27.2.0-non-semver-compat"
+source = "git+https://github.com/matter-labs/zksync-era?rev=core-v27.2.0#0d2bb67af441758690c195380d6f6d137967f19a"
 dependencies = [
  "anyhow",
  "blake2",
@@ -8378,8 +8376,8 @@ dependencies = [
 
 [[package]]
 name = "zksync_da_client"
-version = "27.0.0-non-semver-compat"
-source = "git+https://github.com/matter-labs/zksync-era?rev=core-v27.0.0#3e9fc0a5f6abffdae994e4f22ab21eac95c7ac08"
+version = "27.2.0-non-semver-compat"
+source = "git+https://github.com/matter-labs/zksync-era?rev=core-v27.2.0#0d2bb67af441758690c195380d6f6d137967f19a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8429,8 +8427,8 @@ dependencies = [
 
 [[package]]
 name = "zksync_mini_merkle_tree"
-version = "27.0.0-non-semver-compat"
-source = "git+https://github.com/matter-labs/zksync-era?rev=core-v27.0.0#3e9fc0a5f6abffdae994e4f22ab21eac95c7ac08"
+version = "27.2.0-non-semver-compat"
+source = "git+https://github.com/matter-labs/zksync-era?rev=core-v27.2.0#0d2bb67af441758690c195380d6f6d137967f19a"
 dependencies = [
  "once_cell",
  "zksync_basic_types",
@@ -8439,8 +8437,8 @@ dependencies = [
 
 [[package]]
 name = "zksync_multivm"
-version = "27.0.0-non-semver-compat"
-source = "git+https://github.com/matter-labs/zksync-era?rev=core-v27.0.0#3e9fc0a5f6abffdae994e4f22ab21eac95c7ac08"
+version = "27.2.0-non-semver-compat"
+source = "git+https://github.com/matter-labs/zksync-era?rev=core-v27.2.0#0d2bb67af441758690c195380d6f6d137967f19a"
 dependencies = [
  "anyhow",
  "circuit_sequencer_api",
@@ -8455,7 +8453,7 @@ dependencies = [
  "zk_evm 0.133.0",
  "zk_evm 0.140.0",
  "zk_evm 0.141.0",
- "zk_evm 0.151.3",
+ "zk_evm 0.151.5",
  "zksync_contracts",
  "zksync_mini_merkle_tree",
  "zksync_system_constants",
@@ -8479,8 +8477,8 @@ dependencies = [
 
 [[package]]
 name = "zksync_system_constants"
-version = "27.0.0-non-semver-compat"
-source = "git+https://github.com/matter-labs/zksync-era?rev=core-v27.0.0#3e9fc0a5f6abffdae994e4f22ab21eac95c7ac08"
+version = "27.2.0-non-semver-compat"
+source = "git+https://github.com/matter-labs/zksync-era?rev=core-v27.2.0#0d2bb67af441758690c195380d6f6d137967f19a"
 dependencies = [
  "once_cell",
  "zksync_basic_types",
@@ -8488,8 +8486,8 @@ dependencies = [
 
 [[package]]
 name = "zksync_types"
-version = "27.0.0-non-semver-compat"
-source = "git+https://github.com/matter-labs/zksync-era?rev=core-v27.0.0#3e9fc0a5f6abffdae994e4f22ab21eac95c7ac08"
+version = "27.2.0-non-semver-compat"
+source = "git+https://github.com/matter-labs/zksync-era?rev=core-v27.2.0#0d2bb67af441758690c195380d6f6d137967f19a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8515,8 +8513,8 @@ dependencies = [
 
 [[package]]
 name = "zksync_utils"
-version = "27.0.0-non-semver-compat"
-source = "git+https://github.com/matter-labs/zksync-era?rev=core-v27.0.0#3e9fc0a5f6abffdae994e4f22ab21eac95c7ac08"
+version = "27.2.0-non-semver-compat"
+source = "git+https://github.com/matter-labs/zksync-era?rev=core-v27.2.0#0d2bb67af441758690c195380d6f6d137967f19a"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -8548,8 +8546,8 @@ dependencies = [
 
 [[package]]
 name = "zksync_vm_interface"
-version = "27.0.0-non-semver-compat"
-source = "git+https://github.com/matter-labs/zksync-era?rev=core-v27.0.0#3e9fc0a5f6abffdae994e4f22ab21eac95c7ac08"
+version = "27.2.0-non-semver-compat"
+source = "git+https://github.com/matter-labs/zksync-era?rev=core-v27.2.0#0d2bb67af441758690c195380d6f6d137967f19a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8565,8 +8563,8 @@ dependencies = [
 
 [[package]]
 name = "zksync_web3_decl"
-version = "27.0.0-non-semver-compat"
-source = "git+https://github.com/matter-labs/zksync-era?rev=core-v27.0.0#3e9fc0a5f6abffdae994e4f22ab21eac95c7ac08"
+version = "27.2.0-non-semver-compat"
+source = "git+https://github.com/matter-labs/zksync-era?rev=core-v27.2.0#0d2bb67af441758690c195380d6f6d137967f19a"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/e2e-tests-rust/Cargo.toml
+++ b/e2e-tests-rust/Cargo.toml
@@ -34,3 +34,6 @@ hex = "0.4"
 test-casing = "0.1.3"
 
 [workspace] # ignore higher-level workspace
+
+[patch.crates-io]
+vise = { git = "https://github.com/matter-labs/vise.git", rev = "51669f42f60c50b3a521662a4ecd71212a303299" }


### PR DESCRIPTION
# What :computer: 
Upgrades zksync-era version

# Why :hand:
We should use latest stable zksync-era for the next release
