### PR TITLE
feat: add cli option for local system contracts usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,16 @@ anvil-zksync --external-l1 http://localhost:8545
 
 The system contract within the node can be specified via the `--dev-system-contracts` option.
 It can take one of the following options:
-   * `built-in`: Use the compiled built-in contracts
-   * `built-in-no-verify`: Use the compiled built-in contracts, but without signature verification
-   * `local`: Load contracts from `ZKSYNC_HOME`
+
+- `built-in`: Use the compiled built-in contracts
+- `built-in-no-verify`: Use the compiled built-in contracts, but without signature verification
+- `local`: Load contracts from `ZKSYNC_HOME` or specify path using `--system-contracts-path`
+
+**Example:**
+
+```bash
+anvil-zksync --dev-system-contracts local --system-contracts-path ./system-contracts --protocol-version 28
+```
 
 ## 📃 Logging
 

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -186,7 +186,11 @@ pub struct Cli {
     pub dev_system_contracts: Option<SystemContractsOptions>,
 
     /// Override the location of the compiled system contracts.
-    #[arg(long, help_heading = "System Configuration", value_parser = clap::value_parser!(PathBuf))]
+    #[arg(
+        long,
+        help_heading = "System Configuration",
+        value_parser = clap::value_parser!(PathBuf),
+    )]
     pub system_contracts_path: Option<PathBuf>,
 
     #[arg(long, value_parser = protocol_version_from_str, help_heading = "System Configuration")]

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -185,6 +185,10 @@ pub struct Cli {
     /// Option for system contracts (default: built-in).
     pub dev_system_contracts: Option<SystemContractsOptions>,
 
+    /// Override the location of the compiled system contracts.
+    #[arg(long, help_heading = "System Configuration", value_parser = clap::value_parser!(PathBuf))]
+    pub system_contracts_path: Option<PathBuf>,
+
     #[arg(long, value_parser = protocol_version_from_str, help_heading = "System Configuration")]
     /// Protocol version to use for new blocks (default: 26). Also affects revision of built-in
     /// contracts that will get deployed (if applicable).
@@ -600,6 +604,7 @@ impl Cli {
             .with_show_node_config(self.show_node_config)
             .with_silent(self.silent)
             .with_system_contracts(self.dev_system_contracts)
+            .with_system_contracts_path(self.system_contracts_path.clone())
             .with_protocol_version(self.protocol_version)
             .with_override_bytecodes_dir(self.override_bytecodes_dir.clone())
             .with_enforce_bytecode_compression(self.enforce_bytecode_compression)

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -209,13 +209,10 @@ async fn start_program() -> Result<(), AnvilZksyncError> {
     if let SystemContractsOptions::Local = config.system_contracts_options {
         // if local system contracts specified, check if the path exists else use env var
         // ZKSYNC_HOME
-        let path: Option<PathBuf> = if let Some(ref custom_path) = config.system_contracts_path {
-            Some(custom_path.clone())
-        } else if let Some(env_val) = env::var_os("ZKSYNC_HOME") {
-            Some(PathBuf::from(env_val))
-        } else {
-            None
-        };
+        let path: Option<PathBuf> = config
+            .system_contracts_path
+            .clone()
+            .or_else(|| env::var_os("ZKSYNC_HOME").map(PathBuf::from));
 
         if let Some(path) = path {
             if !path.exists() || !path.is_dir() {

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -75,6 +75,8 @@ pub struct TestNodeConfig {
     pub silent: bool,
     /// Configuration for system contracts
     pub system_contracts_options: SystemContractsOptions,
+    /// Path to the system contracts directory
+    pub system_contracts_path: Option<PathBuf>,
     /// Protocol version to use for new blocks. Also affects revision of built-in contracts that
     /// will get deployed (if applicable)
     pub protocol_version: Option<ProtocolVersionId>,
@@ -190,6 +192,7 @@ impl Default for TestNodeConfig {
             verbosity: 0,
             silent: false,
             system_contracts_options: Default::default(),
+            system_contracts_path: None,
             protocol_version: None,
             override_bytecodes_dir: None,
             bytecode_compression: false,
@@ -587,6 +590,15 @@ Address: {address}
     pub fn with_system_contracts(mut self, option: Option<SystemContractsOptions>) -> Self {
         if let Some(option) = option {
             self.system_contracts_options = option;
+        }
+        self
+    }
+
+    /// Set the system contracts path
+    #[must_use]
+    pub fn with_system_contracts_path(mut self, path: Option<PathBuf>) -> Self {
+        if let Some(path) = path {
+            self.system_contracts_path = Some(path);
         }
         self
     }

--- a/crates/core/src/deps/mod.rs
+++ b/crates/core/src/deps/mod.rs
@@ -1,5 +1,5 @@
 use anvil_zksync_config::types::SystemContractsOptions;
-use std::collections::HashMap;
+use std::{collections::HashMap, path::Path};
 use zksync_multivm::interface::storage::ReadStorage;
 use zksync_types::{
     get_code_key, get_known_code_key, get_system_context_init_logs, L2ChainId, ProtocolVersionId,
@@ -22,9 +22,13 @@ impl InMemoryStorage {
         bytecode_hasher: impl Fn(&[u8]) -> H256,
         system_contracts_options: SystemContractsOptions,
         protocol_version: ProtocolVersionId,
+        system_contracts_path: Option<&Path>,
     ) -> Self {
-        let contracts =
-            system_contracts::get_deployed_contracts(system_contracts_options, protocol_version);
+        let contracts = system_contracts::get_deployed_contracts(
+            system_contracts_options,
+            protocol_version,
+            system_contracts_path,
+        );
 
         let system_context_init_log = get_system_context_init_logs(chain_id);
         let state = contracts

--- a/crates/core/src/node/in_memory.rs
+++ b/crates/core/src/node/in_memory.rs
@@ -656,6 +656,7 @@ impl InMemoryNode {
         let impersonation = ImpersonationManager::default();
         let system_contracts = SystemContracts::from_options(
             config.system_contracts_options,
+            config.system_contracts_path.clone(),
             ProtocolVersionId::latest(),
             config.use_evm_emulator,
             config.use_zkos,

--- a/crates/core/src/node/inner/fork_storage.rs
+++ b/crates/core/src/node/inner/fork_storage.rs
@@ -14,6 +14,7 @@ use eyre::eyre;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 use std::iter::FromIterator;
+use std::path::Path;
 use std::sync::{Arc, RwLock};
 use zksync_multivm::interface::storage::ReadStorage;
 use zksync_types::bytecode::BytecodeHash;
@@ -51,6 +52,7 @@ impl ForkStorage {
         system_contracts_options: SystemContractsOptions,
         protocol_version: ProtocolVersionId,
         override_chain_id: Option<u32>,
+        system_contracts_path: Option<&Path>,
     ) -> Self {
         let chain_id = if let Some(override_id) = override_chain_id {
             L2ChainId::from(override_id)
@@ -67,6 +69,7 @@ impl ForkStorage {
                     |b| BytecodeHash::for_bytecode(b).value(),
                     system_contracts_options,
                     protocol_version,
+                    system_contracts_path,
                 ),
                 value_read_cache: Default::default(),
                 fork,
@@ -391,7 +394,7 @@ mod tests {
 
         let options = SystemContractsOptions::default();
         let mut fork_storage: ForkStorage =
-            ForkStorage::new(fork, options, ProtocolVersionId::latest(), None);
+            ForkStorage::new(fork, options, ProtocolVersionId::latest(), None, None);
 
         assert!(fork_storage.is_write_initial(&never_written_key));
         assert!(!fork_storage.is_write_initial(&key_with_some_value));
@@ -426,6 +429,7 @@ mod tests {
             fork,
             SystemContractsOptions::default(),
             ProtocolVersionId::latest(),
+            None,
             None,
         );
         let new_chain_id = L2ChainId::from(261);

--- a/crates/core/src/node/inner/in_memory_inner.rs
+++ b/crates/core/src/node/inner/in_memory_inner.rs
@@ -1028,6 +1028,7 @@ impl InMemoryNodeInner {
             self.config.system_contracts_options,
             self.blockchain.protocol_version,
             self.config.chain_id,
+            self.config.system_contracts_path.as_deref(),
         );
         let mut old_storage = self.fork_storage.inner.write().unwrap();
         let mut new_storage = fork_storage.inner.write().unwrap();
@@ -1133,6 +1134,7 @@ pub mod testing {
             let impersonation = ImpersonationManager::default();
             let system_contracts = SystemContracts::from_options(
                 config.system_contracts_options,
+                config.system_contracts_path.clone(),
                 ProtocolVersionId::latest(),
                 config.use_evm_emulator,
                 config.use_zkos,

--- a/crates/core/src/node/inner/mod.rs
+++ b/crates/core/src/node/inner/mod.rs
@@ -80,6 +80,7 @@ impl InMemoryNodeInner {
             config.system_contracts_options,
             system_contracts.protocol_version,
             config.chain_id,
+            config.system_contracts_path.as_deref(),
         );
         let vm_runner = VmRunner::new(
             time.clone(),

--- a/crates/core/src/node/inner/vm_runner.rs
+++ b/crates/core/src/node/inner/vm_runner.rs
@@ -619,9 +619,11 @@ mod test {
                 SystemContractsOptions::BuiltIn,
                 ProtocolVersionId::latest(),
                 None,
+                None,
             );
             let system_contracts = SystemContracts::from_options(
                 config.system_contracts_options,
+                config.system_contracts_path.clone(),
                 ProtocolVersionId::latest(),
                 config.use_evm_emulator,
                 config.use_zkos,

--- a/crates/core/src/system_contracts.rs
+++ b/crates/core/src/system_contracts.rs
@@ -1,13 +1,88 @@
+use std::path::{Path, PathBuf};
+
 use crate::deps::system_contracts::load_builtin_contract;
 use crate::node::ImpersonationManager;
 use anvil_zksync_config::types::SystemContractsOptions;
 use zksync_contracts::{
-    read_bootloader_code, read_sys_contract_bytecode, BaseSystemContracts,
-    BaseSystemContractsHashes, ContractLanguage, SystemContractCode,
+    read_sys_contract_bytecode, BaseSystemContracts, BaseSystemContractsHashes, ContractLanguage,
+    SystemContractCode, SystemContractsRepo,
 };
 use zksync_multivm::interface::TxExecutionMode;
 use zksync_types::bytecode::BytecodeHash;
 use zksync_types::{Address, ProtocolVersionId};
+
+/// Builder for SystemContracts
+#[derive(Debug, Default)]
+pub struct SystemContractsBuilder {
+    system_contracts_options: Option<SystemContractsOptions>,
+    system_contracts_path: Option<PathBuf>,
+    protocol_version: Option<ProtocolVersionId>,
+    use_evm_emulator: bool,
+    use_zkos: bool,
+}
+
+impl SystemContractsBuilder {
+    /// Create a new builder with default values
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the system contracts options (e.g. Local, BuiltIn, BuiltInWithoutSecurity)
+    pub fn system_contracts_options(mut self, opts: SystemContractsOptions) -> Self {
+        self.system_contracts_options = Some(opts);
+        self
+    }
+
+    /// Set the system contracts path
+    pub fn system_contracts_path(mut self, path: Option<PathBuf>) -> Self {
+        self.system_contracts_path = path;
+        self
+    }
+
+    /// Set the protocol version
+    pub fn protocol_version(mut self, version: ProtocolVersionId) -> Self {
+        self.protocol_version = Some(version);
+        self
+    }
+
+    /// Enable or disable the EVM emulator
+    pub fn use_evm_emulator(mut self, flag: bool) -> Self {
+        self.use_evm_emulator = flag;
+        self
+    }
+
+    /// Enable or disable ZKOS
+    pub fn use_zkos(mut self, flag: bool) -> Self {
+        self.use_zkos = flag;
+        self
+    }
+
+    /// Build the SystemContracts instance.
+    ///
+    /// This method will panic if the `system_contracts_options` is not provided.
+    /// For the protocol version, if none is provided, the latest version is used.
+    pub fn build(self) -> SystemContracts {
+        let options = self
+            .system_contracts_options
+            .expect("SystemContractsOptions must be provided");
+        let protocol_version = self
+            .protocol_version
+            .unwrap_or_else(ProtocolVersionId::latest);
+
+        tracing::debug!(
+            %protocol_version, use_evm_emulator = self.use_evm_emulator, use_zkos = self.use_zkos,
+            "Building SystemContracts"
+        );
+
+        SystemContracts::from_options(
+            options,
+            self.system_contracts_path,
+            protocol_version,
+            self.use_evm_emulator,
+            self.use_zkos,
+        )
+    }
+}
 
 /// Holds the system contracts (and bootloader) that are used by the in-memory node.
 #[derive(Debug, Clone)]
@@ -26,10 +101,16 @@ pub struct SystemContracts {
 }
 
 impl SystemContracts {
+    /// Creates a builder for SystemContracts
+    pub fn builder() -> SystemContractsBuilder {
+        SystemContractsBuilder::new()
+    }
+
     /// Creates the SystemContracts that use the complied contracts from ZKSYNC_HOME path.
     /// These are loaded at binary runtime.
     pub fn from_options(
         options: SystemContractsOptions,
+        system_contracts_path: Option<PathBuf>,
         protocol_version: ProtocolVersionId,
         use_evm_emulator: bool,
         use_zkos: bool,
@@ -40,24 +121,33 @@ impl SystemContracts {
             use_zkos,
             "initializing system contracts"
         );
+        let path = system_contracts_path.unwrap_or_else(|| SystemContractsRepo::default().root);
         Self {
             protocol_version,
-            baseline_contracts: baseline_contracts(options, protocol_version, use_evm_emulator),
-            playground_contracts: playground(options, protocol_version, use_evm_emulator),
+            baseline_contracts: baseline_contracts(
+                options,
+                protocol_version,
+                use_evm_emulator,
+                &path,
+            ),
+            playground_contracts: playground(options, protocol_version, use_evm_emulator, &path),
             fee_estimate_contracts: fee_estimate_contracts(
                 options,
                 protocol_version,
                 use_evm_emulator,
+                &path,
             ),
             baseline_impersonating_contracts: baseline_impersonating_contracts(
                 options,
                 protocol_version,
                 use_evm_emulator,
+                &path,
             ),
             fee_estimate_impersonating_contracts: fee_estimate_impersonating_contracts(
                 options,
                 protocol_version,
                 use_evm_emulator,
+                &path,
             ),
             use_evm_emulator,
             use_zkos,
@@ -125,7 +215,9 @@ fn bsc_load_with_bootloader(
     options: SystemContractsOptions,
     protocol_version: ProtocolVersionId,
     use_evm_emulator: bool,
+    system_contracts_path: &Path,
 ) -> BaseSystemContracts {
+    let repo = system_contracts_repo(system_contracts_path);
     let hash = BytecodeHash::for_bytecode(&bootloader_bytecode);
 
     let bootloader = SystemContractCode {
@@ -138,7 +230,7 @@ fn bsc_load_with_bootloader(
             load_builtin_contract(protocol_version, "DefaultAccount")
         }
         SystemContractsOptions::Local => {
-            read_sys_contract_bytecode("", "DefaultAccount", ContractLanguage::Sol)
+            repo.read_sys_contract_bytecode("", "DefaultAccount", None, ContractLanguage::Sol)
         }
         SystemContractsOptions::BuiltInWithoutSecurity => {
             load_builtin_contract(protocol_version, "DefaultAccountNoSecurity")
@@ -181,12 +273,19 @@ fn playground(
     options: SystemContractsOptions,
     protocol_version: ProtocolVersionId,
     use_evm_emulator: bool,
+    system_contracts_path: &Path,
 ) -> BaseSystemContracts {
+    let repo = system_contracts_repo(system_contracts_path);
     let bootloader_bytecode = match options {
         SystemContractsOptions::BuiltIn | SystemContractsOptions::BuiltInWithoutSecurity => {
             load_builtin_contract(protocol_version, "playground_batch")
         }
-        SystemContractsOptions::Local => read_bootloader_code("playground_batch"),
+        SystemContractsOptions::Local => repo.read_sys_contract_bytecode(
+            "bootloader",
+            "playground_batch",
+            Some("Bootloader"),
+            ContractLanguage::Yul,
+        ),
     };
 
     bsc_load_with_bootloader(
@@ -194,6 +293,7 @@ fn playground(
         options,
         protocol_version,
         use_evm_emulator,
+        system_contracts_path,
     )
 }
 
@@ -207,12 +307,19 @@ fn fee_estimate_contracts(
     options: SystemContractsOptions,
     protocol_version: ProtocolVersionId,
     use_evm_emulator: bool,
+    system_contracts_path: &Path,
 ) -> BaseSystemContracts {
+    let repo = system_contracts_repo(system_contracts_path);
     let bootloader_bytecode = match options {
         SystemContractsOptions::BuiltIn | SystemContractsOptions::BuiltInWithoutSecurity => {
             load_builtin_contract(protocol_version, "fee_estimate")
         }
-        SystemContractsOptions::Local => read_bootloader_code("fee_estimate"),
+        SystemContractsOptions::Local => repo.read_sys_contract_bytecode(
+            "bootloader",
+            "fee_estimate",
+            Some("Bootloader"),
+            ContractLanguage::Yul,
+        ),
     };
 
     bsc_load_with_bootloader(
@@ -220,6 +327,7 @@ fn fee_estimate_contracts(
         options,
         protocol_version,
         use_evm_emulator,
+        system_contracts_path,
     )
 }
 
@@ -227,13 +335,20 @@ fn fee_estimate_impersonating_contracts(
     options: SystemContractsOptions,
     protocol_version: ProtocolVersionId,
     use_evm_emulator: bool,
+    system_contracts_path: &Path,
 ) -> BaseSystemContracts {
+    let repo = system_contracts_repo(system_contracts_path);
     let bootloader_bytecode = match options {
         SystemContractsOptions::BuiltIn | SystemContractsOptions::BuiltInWithoutSecurity => {
             load_builtin_contract(protocol_version, "fee_estimate_impersonating")
         }
         // Account impersonating is not supported with the local contracts
-        SystemContractsOptions::Local => read_bootloader_code("fee_estimate"),
+        SystemContractsOptions::Local => repo.read_sys_contract_bytecode(
+            "bootloader",
+            "fee_estimate",
+            Some("Bootloader"),
+            ContractLanguage::Yul,
+        ),
     };
 
     bsc_load_with_bootloader(
@@ -241,6 +356,7 @@ fn fee_estimate_impersonating_contracts(
         options,
         protocol_version,
         use_evm_emulator,
+        system_contracts_path,
     )
 }
 
@@ -248,18 +364,26 @@ fn baseline_contracts(
     options: SystemContractsOptions,
     protocol_version: ProtocolVersionId,
     use_evm_emulator: bool,
+    system_contracts_path: &Path,
 ) -> BaseSystemContracts {
+    let repo = system_contracts_repo(system_contracts_path);
     let bootloader_bytecode = match options {
         SystemContractsOptions::BuiltIn | SystemContractsOptions::BuiltInWithoutSecurity => {
             load_builtin_contract(protocol_version, "proved_batch")
         }
-        SystemContractsOptions::Local => read_bootloader_code("proved_batch"),
+        SystemContractsOptions::Local => repo.read_sys_contract_bytecode(
+            "bootloader",
+            "proved_batch",
+            Some("Bootloader"),
+            ContractLanguage::Yul,
+        ),
     };
     bsc_load_with_bootloader(
         bootloader_bytecode,
         options,
         protocol_version,
         use_evm_emulator,
+        system_contracts_path,
     )
 }
 
@@ -267,18 +391,32 @@ fn baseline_impersonating_contracts(
     options: SystemContractsOptions,
     protocol_version: ProtocolVersionId,
     use_evm_emulator: bool,
+    system_contracts_path: &Path,
 ) -> BaseSystemContracts {
+    let repo = system_contracts_repo(system_contracts_path);
     let bootloader_bytecode = match options {
         SystemContractsOptions::BuiltIn | SystemContractsOptions::BuiltInWithoutSecurity => {
             load_builtin_contract(protocol_version, "proved_batch_impersonating")
         }
         // Account impersonating is not supported with the local contracts
-        SystemContractsOptions::Local => read_bootloader_code("proved_batch"),
+        SystemContractsOptions::Local => repo.read_sys_contract_bytecode(
+            "bootloader",
+            "proved_batch",
+            Some("Bootloader"),
+            ContractLanguage::Yul,
+        ),
     };
     bsc_load_with_bootloader(
         bootloader_bytecode,
         options,
         protocol_version,
         use_evm_emulator,
+        system_contracts_path,
     )
+}
+
+fn system_contracts_repo(root: &Path) -> SystemContractsRepo {
+    SystemContractsRepo {
+        root: root.to_path_buf(),
+    }
 }


### PR DESCRIPTION
# What :computer: 
* Adds `--system-contracts-path` as a cli option, can only be used when system contract options are set to local
* Adds SystemContractsBuilder 
* Allows for custom path to be specified for system contract usage

# Why :hand:
* Currently only way was to set env var of ZKSYNC_HOME which also depends on the path being `./contracts/system-contracts`) whereas now devs (protocol team) can simply specify the era-contracts repo.

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

```bash
./target/release/anvil-zksync --dev-system-contracts local --system-contracts-path ./system-contracts --protocol-version 28
```

Once merged / released, can specify in action as such:

```bash
- name: Use anvil-zksync for testing
  uses: dutterbutter/anvil-zksync-action@v1.2.0
  with:
    devSystemContracts: local
    systemContractsPath: ${{ github.workspace }}/system-contracts
    protocolVersion: 28
    logFilePath: anvil_zksync.log
```

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
