### PR TITLE
ci: use proper target commit for manual pre-releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,5 +111,6 @@ jobs:
         with:
           name: 'anvil-zksync ${{ inputs.prerelease_name}} ${{ steps.release_tag.outputs.tag }}'
           tag_name: ${{ steps.release_tag.outputs.tag }}
+          target_commitish: ${{ github.sha }}
           prerelease: true
           files: 'artifacts/**/anvil-zksync*.tar.gz'


### PR DESCRIPTION
# What :computer: 

* [x] Use proper target commit for manual pre-releases.

# Why :hand:

To fix issues with wrong tags for pre-release generation when the pre-release was pointing to latest `main` instead of the commit that triggered the workflow.