### PR TITLE
fix: fix revert messages being appended to every call

### DIFF
--- a/crates/core/src/node/error.rs
+++ b/crates/core/src/node/error.rs
@@ -85,11 +85,11 @@ impl ToRevertReason for VmRevertReason {
             VmRevertReason::InnerTxError => RevertError::InnerTxError,
             VmRevertReason::VmError => RevertError::VmError,
             VmRevertReason::Unknown { .. } => RevertError::Unknown {
-                function_selector: message.encode_hex(),
+                function_selector: message,
                 data: data.encode_hex(),
             },
             _ => RevertError::Unknown {
-                function_selector: message.encode_hex(),
+                function_selector: message,
                 data: data.encode_hex(),
             },
         }

--- a/crates/core/src/node/in_memory.rs
+++ b/crates/core/src/node/in_memory.rs
@@ -439,7 +439,8 @@ impl InMemoryNode {
                 .handle_calls_recursive(&call_traces);
         }
 
-        if !call_traces.is_empty() {
+        let verbosity = get_shell().verbosity;
+        if !call_traces.is_empty() && verbosity >= 2 {
             let tx_result_for_arena = tx_result.clone();
             let mut builder = CallTraceDecoderBuilder::new();
             builder = builder.with_signature_identifier(
@@ -469,12 +470,9 @@ impl InMemoryNode {
                 inner_result
             })?;
 
-            let verbosity = get_shell().verbosity;
-            if verbosity >= 2 {
-                let filtered_arena = filter_call_trace_arena(&arena, verbosity);
-                let trace_output = render_trace_arena_inner(&filtered_arena, false);
-                sh_println!("\nTraces:\n{}", trace_output);
-            }
+            let filtered_arena = filter_call_trace_arena(&arena, verbosity);
+            let trace_output = render_trace_arena_inner(&filtered_arena, false);
+            sh_println!("\nTraces:\n{}", trace_output);
         }
 
         Ok(tx_result.result)

--- a/crates/core/src/node/inner/vm_runner.rs
+++ b/crates/core/src/node/inner/vm_runner.rs
@@ -230,7 +230,8 @@ impl VmRunner {
             formatter.print_vm_details(&tx_result);
         }
 
-        if !call_traces.is_empty() {
+        let verbosity = get_shell().verbosity;
+        if !call_traces.is_empty() && verbosity >= 2 {
             let mut builder = CallTraceDecoderBuilder::new();
 
             builder = builder.with_signature_identifier(
@@ -244,12 +245,10 @@ impl VmRunner {
             let mut arena = build_call_trace_arena(&call_traces, &tx_result);
             decode_trace_arena(&mut arena, &decoder).await?;
 
-            let verbosity = get_shell().verbosity;
-            if verbosity >= 2 {
-                let filtered_arena = filter_call_trace_arena(&arena, verbosity);
-                let trace_output = render_trace_arena_inner(&filtered_arena, false);
-                sh_println!("\nTraces:\n{}", trace_output);
-            }
+            let filtered_arena = filter_call_trace_arena(&arena, verbosity);
+            let trace_output = render_trace_arena_inner(&filtered_arena, false);
+            sh_println!("\nTraces:\n{}", trace_output);
+
             if !config.disable_console_log {
                 self.console_log_handler
                     .handle_calls_recursive(&call_traces);

--- a/crates/traces/src/lib.rs
+++ b/crates/traces/src/lib.rs
@@ -62,7 +62,7 @@ pub fn build_call_trace_arena(
     }
 
     for call in calls {
-        process_call_and_subcalls(call, 0, 0, &mut arena, tx_result);
+        process_call_and_subcalls(call, 0, &mut arena, tx_result);
     }
     arena
 }
@@ -71,7 +71,6 @@ pub fn build_call_trace_arena(
 fn process_call_and_subcalls(
     call: &Call,
     parent_idx: usize,
-    depth: usize,
     arena: &mut CallTraceArena,
     tx_result: &VmExecutionResultAndLogs,
 ) {
@@ -133,7 +132,7 @@ fn process_call_and_subcalls(
 
     // Process subcalls under the new parent.
     for subcall in &call.calls {
-        process_call_and_subcalls(subcall, new_parent_idx, depth + 1, arena, tx_result);
+        process_call_and_subcalls(subcall, new_parent_idx, arena, tx_result);
     }
 }
 

--- a/crates/traces/src/lib.rs
+++ b/crates/traces/src/lib.rs
@@ -17,7 +17,7 @@ pub mod writer;
 fn convert_call_to_call_trace(
     call: &Call,
     depth: usize,
-    tx_result: VmExecutionResultAndLogs,
+    tx_result: &VmExecutionResultAndLogs,
 ) -> CallTrace {
     let label = KNOWN_ADDRESSES
         .get(&call.to)
@@ -27,7 +27,7 @@ fn convert_call_to_call_trace(
         success: !tx_result.result.is_failed(),
         caller: call.from,
         address: call.to,
-        execution_result: tx_result,
+        execution_result: tx_result.result.clone(),
         decoded: DecodedCallTrace {
             label,
             ..Default::default()
@@ -45,7 +45,7 @@ pub fn build_call_trace_arena(
 
     // Update the root node's execution result.
     if let Some(root_node) = arena.arena.get_mut(0) {
-        root_node.trace.execution_result = tx_result.clone();
+        root_node.trace.execution_result = tx_result.result.clone();
     }
 
     for call in calls {
@@ -104,7 +104,7 @@ fn process_call_and_subcalls(
         )
         .collect();
 
-    let call_trace = convert_call_to_call_trace(call, depth, tx_result.clone());
+    let call_trace = convert_call_to_call_trace(call, depth, tx_result);
 
     let node = CallTraceNode {
         parent: None,

--- a/crates/traces/src/lib.rs
+++ b/crates/traces/src/lib.rs
@@ -4,7 +4,9 @@ use anvil_zksync_types::traces::{
 };
 use decode::CallTraceDecoder;
 use writer::TraceWriter;
-use zksync_multivm::interface::{Call, VmExecutionResultAndLogs};
+use zksync_multivm::interface::{
+    Call, ExecutionResult, Halt, VmExecutionResultAndLogs, VmRevertReason,
+};
 use zksync_types::H160;
 
 pub mod abi_utils;
@@ -14,20 +16,31 @@ pub mod writer;
 
 /// Converts a single call into a CallTrace.
 #[inline]
-fn convert_call_to_call_trace(
-    call: &Call,
-    depth: usize,
-    tx_result: &VmExecutionResultAndLogs,
-) -> CallTrace {
+fn convert_call_to_call_trace(call: &Call) -> CallTrace {
     let label = KNOWN_ADDRESSES
         .get(&call.to)
         .map(|known| known.name.clone());
+
+    // Determine the execution result based on individual call
+    let execution_result = if let Some(ref revert_reason) = call.revert_reason {
+        ExecutionResult::Revert {
+            output: VmRevertReason::from(revert_reason.as_bytes()),
+        }
+    } else if let Some(ref err) = call.error {
+        ExecutionResult::Halt {
+            reason: Halt::TracerCustom(err.to_string()),
+        }
+    } else {
+        ExecutionResult::Success {
+            output: call.output.clone(),
+        }
+    };
+
     CallTrace {
-        depth,
-        success: !tx_result.result.is_failed(),
+        success: !execution_result.is_failed(),
         caller: call.from,
         address: call.to,
-        execution_result: tx_result.result.clone(),
+        execution_result,
         decoded: DecodedCallTrace {
             label,
             ..Default::default()
@@ -104,7 +117,7 @@ fn process_call_and_subcalls(
         )
         .collect();
 
-    let call_trace = convert_call_to_call_trace(call, depth, tx_result);
+    let call_trace = convert_call_to_call_trace(call);
 
     let node = CallTraceNode {
         parent: None,

--- a/crates/traces/src/writer.rs
+++ b/crates/traces/src/writer.rs
@@ -362,7 +362,7 @@ impl<W: Write> TraceWriter<W> {
     /// Writes the footer of a call trace.
     fn write_trace_footer(&mut self, trace: &CallTrace) -> io::Result<()> {
         // Use the custom trait to format the execution result
-        let status_str = trace.execution_result.result.display();
+        let status_str = trace.execution_result.display();
 
         // Write the execution result status using the formatted string
         write!(
@@ -381,7 +381,7 @@ impl<W: Write> TraceWriter<W> {
         // Handle contract creation or output data
         if !self.config.write_bytecodes
             && matches!(trace.call.r#type, CallType::Create)
-            && !trace.execution_result.result.is_failed()
+            && !trace.execution_result.is_failed()
         {
             write!(self.writer, " {} bytes of code", trace.call.output.len())?;
         } else if !trace.call.output.is_empty() {

--- a/crates/types/src/traces.rs
+++ b/crates/types/src/traces.rs
@@ -1,7 +1,7 @@
 use lazy_static::lazy_static;
 use serde::Deserialize;
 use std::collections::HashMap;
-use zksync_multivm::interface::{Call, ExecutionResult, VmEvent, VmExecutionResultAndLogs};
+use zksync_multivm::interface::{Call, ExecutionResult, VmEvent};
 use zksync_types::{
     l2_to_l1_log::{SystemL2ToL1Log, UserL2ToL1Log},
     web3::Bytes,
@@ -201,7 +201,7 @@ pub struct CallTrace {
     /// - [`CallKind::Create`] and alike: the address of the created contract
     pub address: Address,
     /// The execution result of the call.
-    pub execution_result: VmExecutionResultAndLogs,
+    pub execution_result: ExecutionResult,
     /// Optional complementary decoded call data.
     pub decoded: DecodedCallTrace,
     /// The call trace
@@ -248,9 +248,7 @@ impl Default for CallTraceNode {
                 success: true,
                 caller: H160::zero(),
                 address: H160::zero(),
-                execution_result: VmExecutionResultAndLogs::mock(ExecutionResult::Success {
-                    output: vec![],
-                }),
+                execution_result: ExecutionResult::Success { output: vec![] },
                 decoded: DecodedCallTrace::default(),
                 call: Call::default(),
             },
@@ -292,9 +290,7 @@ impl Default for CallTraceArena {
                 success: true,
                 caller: H160::zero(),
                 address: H160::zero(),
-                execution_result: VmExecutionResultAndLogs::mock(ExecutionResult::Success {
-                    output: vec![],
-                }),
+                execution_result: ExecutionResult::Success { output: vec![] },
                 decoded: DecodedCallTrace::default(),
                 call: Call::default(),
             },

--- a/crates/types/src/traces.rs
+++ b/crates/types/src/traces.rs
@@ -188,8 +188,6 @@ impl CallLog {
 /// A trace of a call with optional decoded data.
 #[derive(Clone, Debug)]
 pub struct CallTrace {
-    /// The depth of the call.
-    pub depth: usize,
     /// Whether the call was successful.
     pub success: bool,
     /// The caller address.
@@ -244,7 +242,6 @@ impl Default for CallTraceNode {
             children: Vec::new(),
             idx: 0,
             trace: CallTrace {
-                depth: 0,
                 success: true,
                 caller: H160::zero(),
                 address: H160::zero(),
@@ -286,7 +283,6 @@ impl Default for CallTraceArena {
             children: Vec::new(),
             idx: 0,
             trace: CallTrace {
-                depth: 0,
                 success: true,
                 caller: H160::zero(),
                 address: H160::zero(),


### PR DESCRIPTION
# What :computer: 
* Cherry picks commits [fd9fec0](https://github.com/matter-labs/anvil-zksync/pull/645/commits/fd9fec0ebba72073a21dee8d34cba17f543193ee), and [aa7f1aa](https://github.com/matter-labs/anvil-zksync/pull/645/commits/aa7f1aaec31b6aec0eb0b82e1d6c64bbb567206c) 
* Updates `convert_call_to_call_trace` to determine the execution result based on individual call
* Adds condition check earlier for constructing call trace so its not done when verbosity levels are unused

# Why :hand:
* cherry picked commits Closes #662 
* Closes #641 

# Evidence :camera:

Running:

```
./target/release/anvil-zksync -vvv replay_tx --fork-url sepolia-testnet 0x4fb92f25e8a5653aeae89e55e0c5311c2639a1733fec7aa0726b12fc2cc64224
```

The 3 displayed `Revert: Error function_selector` is equal to the number of revert reasons for the raw call trace in the correct depth.

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
