### PR TITLE
feat: add homebrew formula for improved installation

### DIFF
--- a/.github/workflows/bump-homebrew-formula.yml
+++ b/.github/workflows/bump-homebrew-formula.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   bump-formula:
+    permissions:
+      contents: write
     # only run on stable semver tags (v1.2.3, not v1.2.3-rc, or pre-releases)
     if: startsWith(github.event.release.tag_name, 'v') && !contains(github.event.release.tag_name, '-')
     runs-on: ubuntu-latest
@@ -13,56 +15,63 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+          ref: ${{ github.event.repository.default_branch }}
+          token: ${{ secrets.RELEASE_TOKEN }}
 
-      - name: Set up variables
-        id: vars
+      - name: Set up version
         run: |
-          TAG=${{ github.event.release.tag_name }}
-          VER=${TAG#v}
-          echo "VER=$VER" >> $GITHUB_ENV
-
-          # architectures to process
-          echo "arches=(
-            aarch64-apple-darwin
-            x86_64-apple-darwin
-            aarch64-unknown-linux-gnu
-            x86_64-unknown-linux-gnu
-          )" >> $GITHUB_ENV
+            TAG=${{ github.event.release.tag_name }}
+            VER=${TAG#v}
+            echo "TAG=$TAG" >> $GITHUB_ENV
+            echo "VER=$VER" >> $GITHUB_ENV
 
       - name: Download tarballs & compute checksums
         run: |
-          for arch in "${arches[@]}"; do
-            URL="https://github.com/matter-labs/anvil-zksync/releases/download/$TAG/anvil-zksync-$TAG-$arch.tar.gz"
-            SHA=$(curl -sL "$URL" | sha256sum | awk '{print $1}')
-            # export each as ENV var: SHA_aarch64_apple_darwin, etc.
-            varname="SHA_${arch//[-]/_}"
-            echo "$varname=$SHA" >> $GITHUB_ENV
-          done
+            arches=(
+                aarch64-apple-darwin
+                x86_64-apple-darwin
+                aarch64-unknown-linux-gnu
+                x86_64-unknown-linux-gnu
+            )
+
+            for arch in "${arches[@]}"; do
+                url="https://github.com/matter-labs/anvil-zksync/releases/download/v${VER}/anvil-zksync-v${VER}-${arch}.tar.gz"
+                sha=$(curl -sL "$url" | sha256sum | awk '{print $1}')
+                varname="SHA_${arch//[-]/_}"
+                echo "$varname=$sha" >> $GITHUB_ENV
+            done
 
       - name: Patch Formula/anvil-zksync.rb
         run: |
-          sed -i.bak \
-            -e "s/^  version \".*\"/  version \"$VER\"/" \
-            Formula/anvil-zksync.rb
+            sed -i -E "s|version \".*\"|version \"${VER}\"|" Formula/anvil-zksync.rb
 
-          # update each sha256 line by matching the URL suffix
-          declare -A Mappings=(
-            [aarch64_apple_darwin]="${SHA_aarch64_apple_darwin}"
-            [x86_64_apple_darwin]="${SHA_x86_64_apple_darwin}"
-            [aarch64_unknown_linux_gnu]="${SHA_aarch64_unknown_linux_gnu}"
-            [x86_64_unknown_linux_gnu]="${SHA_x86_64_unknown_linux_gnu}"
-          )
+            declare -A checksums=(
+                ["aarch64-apple-darwin"]="${SHA_aarch64_apple_darwin}"
+                ["x86_64-apple-darwin"]="${SHA_x86_64_apple_darwin}"
+                ["aarch64-unknown-linux-gnu"]="${SHA_aarch64_unknown_linux_gnu}"
+                ["x86_64-unknown-linux-gnu"]="${SHA_x86_64_unknown_linux_gnu}"
+            )
+            
+            for arch in "${!checksums[@]}"; do
+                sha="${checksums[$arch]}"
+                sed -i -E "/${arch}\.tar\.gz\"/{
+                    n
+                    s|sha256 \".*\"|sha256 \"${sha}\"|
+                }" Formula/anvil-zksync.rb
+            done
 
-          for key in "${!Mappings[@]}"; do
-            arch="${key//_/[-]/g}"
-            sha="${Mappings[$key]}"
-            # replace the old sha for the matching tarball line
-            sed -i.bak \
-              -E "/anvil-zksync-v\${VER}-$arch\\.tar\\.gz/ s/sha256 \".*\"/sha256 \"$sha\"/" \
-              Formula/anvil-zksync.rb
-          done
-
-      - name: Commit & push bump
-        run: |
-            TODO
+            git add Formula/anvil-zksync.rb
+    
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.RELEASE_TOKEN }}
+          commit-message: 'chore: bump homebrew formula to ${{ env.VER }}'
+          title: 'chore: bump homebrew formula to ${{ env.VER }}'
+          body: |
+            Bump Homebrew formula for anvil-zksync to version ${{ env.VER }}
+            SHA256 checksums updated for all architectures.
+          branch: bump-homebrew-${{ env.VER }}
+          base: ${{ github.event.repository.default_branch }}
+          add-paths: Formula/anvil-zksync.rb

--- a/.github/workflows/bump-homebrew-formula.yml
+++ b/.github/workflows/bump-homebrew-formula.yml
@@ -15,8 +15,6 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
-          ref: ${{ github.event.repository.default_branch }}
           token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Set up version

--- a/.github/workflows/bump-homebrew-formula.yml
+++ b/.github/workflows/bump-homebrew-formula.yml
@@ -1,0 +1,68 @@
+name: Bump Homebrew formula
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  bump-formula:
+    # only run on stable semver tags (v1.2.3, not v1.2.3-rc, or pre-releases)
+    if: startsWith(github.event.release.tag_name, 'v') && !contains(github.event.release.tag_name, '-')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up variables
+        id: vars
+        run: |
+          TAG=${{ github.event.release.tag_name }}
+          VER=${TAG#v}
+          echo "VER=$VER" >> $GITHUB_ENV
+
+          # architectures to process
+          echo "arches=(
+            aarch64-apple-darwin
+            x86_64-apple-darwin
+            aarch64-unknown-linux-gnu
+            x86_64-unknown-linux-gnu
+          )" >> $GITHUB_ENV
+
+      - name: Download tarballs & compute checksums
+        run: |
+          for arch in "${arches[@]}"; do
+            URL="https://github.com/matter-labs/anvil-zksync/releases/download/$TAG/anvil-zksync-$TAG-$arch.tar.gz"
+            SHA=$(curl -sL "$URL" | sha256sum | awk '{print $1}')
+            # export each as ENV var: SHA_aarch64_apple_darwin, etc.
+            varname="SHA_${arch//[-]/_}"
+            echo "$varname=$SHA" >> $GITHUB_ENV
+          done
+
+      - name: Patch Formula/anvil-zksync.rb
+        run: |
+          sed -i.bak \
+            -e "s/^  version \".*\"/  version \"$VER\"/" \
+            Formula/anvil-zksync.rb
+
+          # update each sha256 line by matching the URL suffix
+          declare -A Mappings=(
+            [aarch64_apple_darwin]="${SHA_aarch64_apple_darwin}"
+            [x86_64_apple_darwin]="${SHA_x86_64_apple_darwin}"
+            [aarch64_unknown_linux_gnu]="${SHA_aarch64_unknown_linux_gnu}"
+            [x86_64_unknown_linux_gnu]="${SHA_x86_64_unknown_linux_gnu}"
+          )
+
+          for key in "${!Mappings[@]}"; do
+            arch="${key//_/[-]/g}"
+            sha="${Mappings[$key]}"
+            # replace the old sha for the matching tarball line
+            sed -i.bak \
+              -E "/anvil-zksync-v\${VER}-$arch\\.tar\\.gz/ s/sha256 \".*\"/sha256 \"$sha\"/" \
+              Formula/anvil-zksync.rb
+          done
+
+      - name: Commit & push bump
+        run: |
+            TODO

--- a/Formula/anvil-zksync.rb
+++ b/Formula/anvil-zksync.rb
@@ -1,0 +1,39 @@
+class AnvilZksync < Formula
+    desc "An in-memory ZKSync node for fast Elastic Network ZK chain development"
+    homepage "https://github.com/matter-labs/anvil-zksync"
+    version "0.5.1"
+  
+    on_macos do
+      if Hardware::CPU.arm?
+        url "https://github.com/matter-labs/anvil-zksync/releases/download/v#{version}/anvil-zksync-v#{version}-aarch64-apple-darwin.tar.gz"
+        sha256 "b374c9e2874d65aeeb90aae6ba04a81fbf89ee6fd61add8f6711472986a66aac"
+      else
+        url "https://github.com/matter-labs/anvil-zksync/releases/download/v#{version}/anvil-zksync-v#{version}-x86_64-apple-darwin.tar.gz"
+        sha256 "35bb3a9fb801570ce758ab873f8c87038aecf2dd1bd016587ae04c1cfbcc790e"
+      end
+    end
+  
+    on_linux do
+      if Hardware::CPU.arm?
+        url "https://github.com/matter-labs/anvil-zksync/releases/download/v#{version}/anvil-zksync-v#{version}-aarch64-unknown-linux-gnu.tar.gz"
+        sha256 "1edb7b4ad49f0896ddf893defb35ca7e1c6a31f1f87df7503468b3ba8d6f79ae"
+      else
+        url "https://github.com/matter-labs/anvil-zksync/releases/download/v#{version}/anvil-zksync-v#{version}-x86_64-unknown-linux-gnu.tar.gz"
+        sha256 "a16d1652a5bf1b319c4b138cc4a63393bae23647bb535308a3bec58885226aa1"
+      end
+    end
+  
+    def install
+      bin.install "anvil-zksync"
+    end
+  
+    test do
+      assert_match version, shell_output("#{bin}/anvil-zksync --version")
+    end
+  
+    livecheck do
+      url :stable
+      regex(/^v?(\d+(?:\.\d+)+)$/i)
+    end
+  end
+  

--- a/Formula/anvil-zksync.rb
+++ b/Formula/anvil-zksync.rb
@@ -36,4 +36,3 @@ class AnvilZksync < Formula
       regex(/^v?(\d+(?:\.\d+)+)$/i)
     end
   end
-  


### PR DESCRIPTION
This is WIP until `bump-homebrew-formula.yaml` is complete as we need to bump the sha hash for each versioned release. 

# What :computer: 
* Adds homebrew formula for improved installation
* Adds GH workflow for bumping version and sha hash upon versioned releases

# Why :hand:
* Folks that want to use anvil-zksync but not foundry-zksync, for folks that want to install anvil-zksync not have their foundry installation overridden
* Make it easier to install 
* Script needs to reflect latest versioned release available

**Example usage:**
```bash
# Need to tap as its not in homebrew/core
brew tap matter-labs/anvil-zksync

# Install
brew install anvil-zksync

# To update later:
brew update
brew upgrade anvil-zksync
```

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
