### PR TITLE
feat: update zksync-error version to support overrides

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8310,7 +8310,7 @@ dependencies = [
 [[package]]
 name = "zksync-error-codegen"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-error?rev=c2ca62ae104389369e2a7cc372b12f764896878d#c2ca62ae104389369e2a7cc372b12f764896878d"
+source = "git+https://github.com/matter-labs/zksync-error?rev=54e0671189a5bc2ce88e72c36334f98fbbdd228d#54e0671189a5bc2ce88e72c36334f98fbbdd228d"
 dependencies = [
  "cargo_metadata",
  "include_dir",
@@ -8333,7 +8333,7 @@ dependencies = [
 [[package]]
 name = "zksync-error-description"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-error?rev=c2ca62ae104389369e2a7cc372b12f764896878d#c2ca62ae104389369e2a7cc372b12f764896878d"
+source = "git+https://github.com/matter-labs/zksync-error?rev=54e0671189a5bc2ce88e72c36334f98fbbdd228d#54e0671189a5bc2ce88e72c36334f98fbbdd228d"
 dependencies = [
  "serde",
  "serde_json",
@@ -8343,7 +8343,7 @@ dependencies = [
 [[package]]
 name = "zksync-error-model"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-error?rev=c2ca62ae104389369e2a7cc372b12f764896878d#c2ca62ae104389369e2a7cc372b12f764896878d"
+source = "git+https://github.com/matter-labs/zksync-error?rev=54e0671189a5bc2ce88e72c36334f98fbbdd228d#54e0671189a5bc2ce88e72c36334f98fbbdd228d"
 dependencies = [
  "const_format",
  "derive_more 2.0.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1943,16 +1943,16 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.18.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
 dependencies = [
  "camino",
  "cargo-platform",
  "semver 1.0.26",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -2262,21 +2262,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const_format"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
-
-[[package]]
-name = "contracts"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9424f2ca1e42776615720e5746eed6efa19866fdbaac2923ab51c294ac4d1f2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "convert_case"
@@ -3260,17 +3269,6 @@ dependencies = [
  "typenum",
  "version_check",
  "zeroize",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -5266,7 +5264,7 @@ dependencies = [
  "lazy_static",
  "num-traits",
  "rand 0.8.5",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_xorshift",
  "regex-syntax 0.8.5",
  "rusty-fork",
@@ -5394,37 +5392,14 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.4",
  "serde",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -5454,29 +5429,11 @@ checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
-]
-
-[[package]]
-name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.15",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -7511,16 +7468,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
-name = "vector-map"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "550f72ae94a45c0e2139188709e6c4179f0b5ff9bdaa435239ad19048b0cd68c"
-dependencies = [
- "contracts",
- "rand 0.7.3",
-]
-
-[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7582,12 +7529,6 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -8369,10 +8310,9 @@ dependencies = [
 [[package]]
 name = "zksync-error-codegen"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-error?rev=fa6e84e06191a1b66323d69ab909fd83ae76e0d2#fa6e84e06191a1b66323d69ab909fd83ae76e0d2"
+source = "git+https://github.com/matter-labs/zksync-error?rev=c2ca62ae104389369e2a7cc372b12f764896878d#c2ca62ae104389369e2a7cc372b12f764896878d"
 dependencies = [
  "cargo_metadata",
- "derive_more 2.0.1",
  "include_dir",
  "maplit",
  "proc-macro2",
@@ -8382,13 +8322,10 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_json_path_to_error",
- "strum 0.26.3",
- "strum_macros 0.26.4",
- "syn 2.0.98",
+ "strum 0.27.1",
+ "strum_macros 0.27.1",
  "tera",
- "thiserror 1.0.69",
- "tracing",
- "vector-map",
+ "thiserror 2.0.11",
  "zksync-error-description",
  "zksync-error-model",
 ]
@@ -8396,7 +8333,7 @@ dependencies = [
 [[package]]
 name = "zksync-error-description"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-error?rev=fa6e84e06191a1b66323d69ab909fd83ae76e0d2#fa6e84e06191a1b66323d69ab909fd83ae76e0d2"
+source = "git+https://github.com/matter-labs/zksync-error?rev=c2ca62ae104389369e2a7cc372b12f764896878d#c2ca62ae104389369e2a7cc372b12f764896878d"
 dependencies = [
  "serde",
  "serde_json",
@@ -8406,13 +8343,12 @@ dependencies = [
 [[package]]
 name = "zksync-error-model"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-error?rev=fa6e84e06191a1b66323d69ab909fd83ae76e0d2#fa6e84e06191a1b66323d69ab909fd83ae76e0d2"
+source = "git+https://github.com/matter-labs/zksync-error?rev=c2ca62ae104389369e2a7cc372b12f764896878d#c2ca62ae104389369e2a7cc372b12f764896878d"
 dependencies = [
+ "const_format",
  "derive_more 2.0.1",
  "serde",
- "serde_json",
- "thiserror 1.0.69",
- "vector-map",
+ "thiserror 2.0.11",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,8 @@ zksync_types = { git = "https://github.com/matter-labs/zksync-era", rev = "core-
 zksync_vm_interface = { git = "https://github.com/matter-labs/zksync-era", rev = "core-v27.2.0" }
 zksync_web3_decl = { git = "https://github.com/matter-labs/zksync-era", rev = "core-v27.2.0" }
 zksync_telemetry = { git = "https://github.com/matter-labs/zksync-telemetry.git", rev = "f6d8618d870a09467ff24ea32ef57e01af8f311e" }
-zksync-error-codegen = { git = "https://github.com/matter-labs/zksync-error", rev = "fa6e84e06191a1b66323d69ab909fd83ae76e0d2", default-features = false }
-zksync-error-description = { git = "https://github.com/matter-labs/zksync-error", rev = "fa6e84e06191a1b66323d69ab909fd83ae76e0d2" }
+zksync-error-codegen = { git = "https://github.com/matter-labs/zksync-error", rev = "c2ca62ae104389369e2a7cc372b12f764896878d", default-features = false }
+zksync-error-description = { git = "https://github.com/matter-labs/zksync-error", rev = "c2ca62ae104389369e2a7cc372b12f764896878d" }
 
 #########################
 # External dependencies #

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,8 @@ zksync_types = { git = "https://github.com/matter-labs/zksync-era", rev = "core-
 zksync_vm_interface = { git = "https://github.com/matter-labs/zksync-era", rev = "core-v27.2.0" }
 zksync_web3_decl = { git = "https://github.com/matter-labs/zksync-era", rev = "core-v27.2.0" }
 zksync_telemetry = { git = "https://github.com/matter-labs/zksync-telemetry.git", rev = "f6d8618d870a09467ff24ea32ef57e01af8f311e" }
-zksync-error-codegen = { git = "https://github.com/matter-labs/zksync-error", rev = "c2ca62ae104389369e2a7cc372b12f764896878d", default-features = false }
-zksync-error-description = { git = "https://github.com/matter-labs/zksync-error", rev = "c2ca62ae104389369e2a7cc372b12f764896878d" }
+zksync-error-codegen = { git = "https://github.com/matter-labs/zksync-error", rev = "54e0671189a5bc2ce88e72c36334f98fbbdd228d", default-features = false }
+zksync-error-description = { git = "https://github.com/matter-labs/zksync-error", rev = "54e0671189a5bc2ce88e72c36334f98fbbdd228d" }
 
 #########################
 # External dependencies #

--- a/crates/core/build.rs
+++ b/crates/core/build.rs
@@ -27,7 +27,11 @@ fn main() -> ExitCode {
 
     let arguments = GenerationArguments {
         verbose: true,
-        root_link: root_link.into(),
+        input_links: vec![root_link.into()],
+        override_links: vec![
+            ( "https://raw.githubusercontent.com/matter-labs/anvil-zksync/refs/heads/main/etc/errors/anvil.json".to_owned(),
+               local_anvil_path)
+        ],
         outputs: vec![
             // Overwrite the crate `zksync-error`, add the converter from
             // `anyhow` to a generic error of the appropriate domain.
@@ -39,8 +43,7 @@ fn main() -> ExitCode {
                     ("generate_cargo_toml".to_owned(), "false".to_owned()),
                 ],
             },
-        ],
-        input_links: vec![local_anvil_path],
+            ],
     };
     if let Err(e) = zksync_error_codegen::load_and_generate(arguments) {
         println!("{e}");

--- a/crates/zksync_error/resources/error-model-dump.json
+++ b/crates/zksync_error/resources/error-model-dump.json
@@ -417,8 +417,8 @@
         "identifier": "anvil_zksync",
         "description": "Errors originating in Anvil for ZKsync.",
         "origins": [
-          "<default zksync-root.json>",
-          "../../etc/errors/anvil.json"
+          "../../etc/errors/anvil.json",
+          "<default zksync-root.json>"
         ]
       },
       "Compiler": {


### PR DESCRIPTION
# TODO
- [ ] merge https://github.com/matter-labs/zksync-error/pull/38
- [ ] update the commit hash of `zksync-error-codegen` and `zksync-error-description` to the new head of `main` in `zksync-error`.
- [ ] Merge this PR

# What :computer: 
* updated zksync-error version
* updated zksync-error interface in `build.rs`

# Why :hand:
* Now zksync-error implements a link remapping that allows substituting `anvil.json` hosted on Github with its local modified copy. 

# Evidence :camera:
Intended as transparent.