### PR TITLE
fix: respect zero value in local storage

### DIFF
--- a/crates/core/src/deps/mod.rs
+++ b/crates/core/src/deps/mod.rs
@@ -58,6 +58,10 @@ impl InMemoryStorage {
         }
     }
 
+    pub fn read_value_opt(&self, key: &StorageKey) -> Option<StorageValue> {
+        self.state.get(key).copied()
+    }
+
     /// Sets the storage `value` at the specified `key`.
     pub fn set_value(&mut self, key: StorageKey, value: StorageValue) {
         self.state.insert(key, value);


### PR DESCRIPTION
# What :computer: 
Closes #676 

Looks like an ancient bug, surprised we only caught it just now

# Why :hand:
Zero values in local storage are treated as missing values when sometimes they are legitimate zeroes
