### PR TITLE
fix: update docker buildx for proper containers caching

### DIFF
--- a/.github/workflows/build-push-docker.yml
+++ b/.github/workflows/build-push-docker.yml
@@ -55,6 +55,8 @@ jobs:
 
       - name: Set Up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          version: latest
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6

--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -18,6 +18,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          version: latest
 
       - name: Build Docker image locally
         id: docker_build


### PR DESCRIPTION
# What :computer: 

* [x] update docker buildx for proper containers caching

# Why :hand:

Older v0.16.x buildx action is using outdated github service for caching.
