### PR TITLE
fix: Update nonces for accounts during impersonation

### DIFF
--- a/crates/core/src/node/inner/mod.rs
+++ b/crates/core/src/node/inner/mod.rs
@@ -88,6 +88,7 @@ impl InMemoryNodeInner {
             system_contracts.clone(),
             generate_system_logs,
             config.is_bytecode_compression_enforced(),
+            storage_key_layout,
         );
 
         let node_inner = InMemoryNodeInner::new(

--- a/e2e-tests/test/anvil-apis.test.ts
+++ b/e2e-tests/test/anvil-apis.test.ts
@@ -320,6 +320,7 @@ describe("anvil_impersonateAccount & anvil_stopImpersonatingAccount", function (
     const userWallet = new Wallet(Wallet.createRandom().privateKey).connect(provider);
     const richAccount = RichAccounts[5].Account;
     const beforeBalance = await provider.getBalance(richAccount);
+    const nonceBefore = await provider.getTransactionCount(userWallet);
 
     // Act
     await provider.send("anvil_impersonateAccount", [richAccount]);
@@ -338,6 +339,7 @@ describe("anvil_impersonateAccount & anvil_stopImpersonatingAccount", function (
     // Assert
     expect(await userWallet.getBalance()).to.eq(ethers.parseEther("0.42"));
     expect(await provider.getBalance(richAccount)).to.eq(beforeBalance - ethers.parseEther("0.42"));
+    expect(await provider.getTransactionCount(richAccount)).to.eq(nonceBefore + 1);
   });
 });
 

--- a/e2e-tests/test/hardhat-apis.test.ts
+++ b/e2e-tests/test/hardhat-apis.test.ts
@@ -63,12 +63,14 @@ describe("hardhat_impersonateAccount & hardhat_stopImpersonatingAccount", functi
   it("Should allow transfers of funds without knowing the Private Key", async function () {
     // Arrange
     const userWallet = new Wallet(Wallet.createRandom().privateKey).connect(provider);
-    const beforeBalance = await provider.getBalance(RichAccounts[5].Account);
+    const richAccount = RichAccounts[5].Account;
+    const beforeBalance = await provider.getBalance(richAccount);
+    const nonceBefore = await provider.getTransactionCount(richAccount);
 
     // Act
-    await provider.send("hardhat_impersonateAccount", [RichAccounts[5].Account]);
+    await provider.send("hardhat_impersonateAccount", [richAccount]);
 
-    const signer = await ethers.getSigner(RichAccounts[5].Account);
+    const signer = await ethers.getSigner(richAccount);
     const tx = {
       to: userWallet.address,
       value: ethers.parseEther("0.42"),
@@ -77,11 +79,12 @@ describe("hardhat_impersonateAccount & hardhat_stopImpersonatingAccount", functi
     const recieptTx = await signer.sendTransaction(tx);
     await recieptTx.wait();
 
-    await provider.send("hardhat_stopImpersonatingAccount", [RichAccounts[5].Account]);
+    await provider.send("hardhat_stopImpersonatingAccount", [richAccount]);
 
     // Assert
     expect(await userWallet.getBalance()).to.eq(ethers.parseEther("0.42"));
-    expect(await provider.getBalance(RichAccounts[5].Account)).to.eq(beforeBalance - ethers.parseEther("0.42"));
+    expect(await provider.getBalance(richAccount)).to.eq(beforeBalance - ethers.parseEther("0.42"));
+    expect(await provider.getTransactionCount(richAccount)).to.eq(nonceBefore + 1);
   });
 });
 


### PR DESCRIPTION
Right now, during impersonation, we don't update account nonces, which can cause issues in some cases (e.g. if we submit N transactions and wait for the nonce to become X).
This PR fixes it by manually setting a new nonce for all the non-halted impersonated transactions.

Probably, in an ideal world it should be handled by the impersonated account itself (e.g. we only skip checking the signature), but it would be much harder to implement.