### PR TITLE
fix: return deployment nonce for contracts in `eth_getTransactionCount`

### DIFF
--- a/crates/core/src/node/eth.rs
+++ b/crates/core/src/node/eth.rs
@@ -1,6 +1,5 @@
 use crate::formatter::ExecutionErrorReport;
 use crate::node::error::{ToHaltError, ToRevertReason};
-use anvil_zksync_common::utils::numbers::h256_to_u64;
 use anvil_zksync_common::{sh_err, sh_println, sh_warn};
 use anyhow::Context as _;
 use std::collections::HashSet;
@@ -8,10 +7,11 @@ use zksync_error::anvil_zksync::{halt::HaltError, revert::RevertError};
 use zksync_multivm::interface::ExecutionResult;
 use zksync_multivm::vm_latest::constants::ETH_CALL_GAS_LIMIT;
 use zksync_types::api::state_override::StateOverride;
+use zksync_types::utils::decompose_full_nonce;
 use zksync_types::{
     api,
     api::{Block, BlockIdVariant, BlockNumber, TransactionVariant},
-    get_code_key,
+    get_code_key, get_is_account_key,
     l2::L2Tx,
     transaction_request::TransactionRequest,
     PackedEthSignature, MAX_L1_TRANSACTION_GAS_LIMIT,
@@ -279,19 +279,20 @@ impl InMemoryNode {
         _block: Option<BlockIdVariant>,
     ) -> anyhow::Result<U256> {
         let nonce_key = self.storage_key_layout.get_nonce_key(&address);
-        match self.storage.read_value_alt(&nonce_key).await {
-            Ok(result) => {
-                // The storage slot contains the full nonce.
-                // Full nonce is a composite one: it includes both account nonce
-                // (number of transactions initiated by the account) and
-                // deployer nonce (number of smart contracts deployed by the
-                // account).
-                // We need to cut the lowest 64 bits to get an account nonce.
-                // See functions: `decompose_full_nonce`, `nonces_to_full_nonce`
-                // https://github.com/matter-labs/zksync-era/blob/8063281579e4e02482823f09997244de153db87e/core/lib/types/src/utils.rs#L42-L52
-                Ok(h256_to_u64(result).into())
-            }
-            Err(error) => Err(anyhow::anyhow!("failed to read nonce storage: {error}")),
+        let code_key = get_code_key(&address);
+        let is_account_key = get_is_account_key(&address);
+
+        let full_nonce = self.storage.read_value_alt(&nonce_key).await?;
+        let (account_nonce, deployment_nonce) = decompose_full_nonce(h256_to_u256(full_nonce));
+        let code_hash = self.storage.read_value_alt(&code_key).await?;
+        let account_info = self.storage.read_value_alt(&is_account_key).await?;
+
+        if code_hash.is_zero() || !account_info.is_zero() {
+            // Return account nonce for EOA accounts
+            Ok(account_nonce)
+        } else {
+            // Return deployment nonce for contracts
+            Ok(deployment_nonce)
         }
     }
 


### PR DESCRIPTION
# What :computer: 

anvil-zksync equivalent of https://github.com/matter-labs/zksync-era/pull/3833

# Why :hand:

Matching core's behavior