### PR TITLE
Iz/fix estimates

### DIFF
--- a/crates/api_server/src/error.rs
+++ b/crates/api_server/src/error.rs
@@ -72,7 +72,28 @@ impl RpcErrorAdapter for StateLoaderError {
 /// All Anvil node errors are treated as internal errors.
 impl RpcErrorAdapter for AnvilNodeError {
     fn into(error: Self) -> ErrorObjectOwned {
-        to_rpc(Some(ErrorCode::InternalError.code()), error)
+        // Map the Web3Error to an appropriate RPC error code
+        match &error {
+            AnvilNodeError::TransactionGasEstimationFailed {
+                transaction_data, ..
+            } => {
+                // We keep previously used `Web3Error::SubmitTransactionError`
+                // for an outside user.
+                RpcErrorAdapter::into(Web3Error::SubmitTransactionError(
+                    error.to_unified().get_message(),
+                    transaction_data.clone(),
+                ))
+            }
+            AnvilNodeError::SerializationError { .. } => {
+                // We keep previously used `Web3Error::SubmitTransactionError`
+                // for an outside user.
+                RpcErrorAdapter::into(Web3Error::SubmitTransactionError(
+                    error.to_unified().get_message(),
+                    vec![],
+                ))
+            }
+            _ => to_rpc(Some(RpcErrorCode::InternalError.code()), error),
+        }
     }
 }
 

--- a/crates/core/src/node/eth.rs
+++ b/crates/core/src/node/eth.rs
@@ -4,6 +4,7 @@ use anvil_zksync_common::utils::numbers::h256_to_u64;
 use anvil_zksync_common::{sh_err, sh_println, sh_warn};
 use anyhow::Context as _;
 use std::collections::HashSet;
+use zksync_error::anvil_zksync::node::AnvilNodeResult;
 use zksync_error::anvil_zksync::{halt::HaltError, revert::RevertError};
 use zksync_multivm::interface::ExecutionResult;
 use zksync_multivm::vm_latest::constants::ETH_CALL_GAS_LIMIT;
@@ -323,7 +324,7 @@ impl InMemoryNode {
         req: zksync_types::transaction_request::CallRequest,
         // TODO: Support
         _block: Option<BlockNumber>,
-    ) -> Result<U256, Web3Error> {
+    ) -> AnvilNodeResult<U256> {
         let fee = self.inner.read().await.estimate_gas_impl(req).await?;
         Ok(fee.gas_limit)
     }

--- a/crates/core/src/node/inner/in_memory_inner.rs
+++ b/crates/core/src/node/inner/in_memory_inner.rs
@@ -31,7 +31,6 @@ use anvil_zksync_traces::identifier::SignaturesIdentifier;
 use anvil_zksync_traces::{
     build_call_trace_arena, decode_trace_arena, filter_call_trace_arena, render_trace_arena_inner,
 };
-use colored::Colorize;
 use indexmap::IndexMap;
 use once_cell::sync::OnceCell;
 use std::collections::{HashMap, HashSet};
@@ -39,7 +38,10 @@ use std::str::FromStr;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use zksync_contracts::{BaseSystemContracts, BaseSystemContractsHashes};
-use zksync_error::anvil_zksync::node::AnvilNodeResult;
+use zksync_error::anvil_zksync::gas_estim;
+use zksync_error::anvil_zksync::node::{
+    AnvilNodeError, AnvilNodeResult, TransactionGasEstimationFailed,
+};
 use zksync_error::anvil_zksync::state::{StateLoaderError, StateLoaderResult};
 use zksync_error::anvil_zksync::{halt::HaltError, revert::RevertError};
 use zksync_multivm::interface::storage::{ReadStorage, StorageView, WriteStorage};
@@ -469,7 +471,9 @@ impl InMemoryNodeInner {
     /// # Returns
     ///
     /// A `Result` with a `Fee` representing the estimated gas related data.
-    pub async fn estimate_gas_impl(&self, req: CallRequest) -> Result<Fee, Web3Error> {
+    pub async fn estimate_gas_impl(&self, req: CallRequest) -> AnvilNodeResult<Fee> {
+        let from = req.from;
+        let to = req.to;
         let mut request_with_gas_per_pubdata_overridden = req;
 
         // If not passed, set request nonce to the expected value
@@ -500,8 +504,13 @@ impl InMemoryNodeInner {
             MAX_TX_SIZE,
             self.system_contracts.allow_no_target(),
         )
-        .map_err(Web3Error::SerializationError)?;
-
+        .map_err(
+            |inner| zksync_error::anvil_zksync::node::SerializationError {
+                from: Box::new(from.unwrap_or_default().into()),
+                to: Box::new(to.unwrap_or_default().into()),
+                reason: inner.to_string(),
+            },
+        )?;
         // Properly format signature
         if l2_tx.common_data.signature.is_empty() {
             l2_tx.common_data.signature = vec![0u8; 65];
@@ -520,7 +529,10 @@ impl InMemoryNodeInner {
         self.estimate_gas_inner(l2_tx.into()).await
     }
 
-    pub async fn estimate_l1_to_l2_gas_impl(&self, req: CallRequest) -> Result<U256, Web3Error> {
+    pub async fn estimate_l1_to_l2_gas_impl(&self, req: CallRequest) -> AnvilNodeResult<U256> {
+        let from = req.from;
+        let to = req.to;
+
         let mut request_with_gas_per_pubdata_overridden = req;
 
         if let Some(ref mut eip712_meta) = request_with_gas_per_pubdata_overridden.eip712_meta {
@@ -534,12 +546,18 @@ impl InMemoryNodeInner {
             request_with_gas_per_pubdata_overridden,
             self.system_contracts.allow_no_target(),
         )
-        .map_err(Web3Error::SerializationError)?;
+        .map_err(
+            |inner| zksync_error::anvil_zksync::node::SerializationError {
+                from: Box::new(from.unwrap_or_default().into()),
+                to: Box::new(to.unwrap_or_default().into()),
+                reason: inner.to_string(),
+            },
+        )?;
 
         Ok(self.estimate_gas_inner(l1_tx.into()).await?.gas_limit)
     }
 
-    async fn estimate_gas_inner(&self, mut tx: Transaction) -> Result<Fee, Web3Error> {
+    async fn estimate_gas_inner(&self, mut tx: Transaction) -> AnvilNodeResult<Fee> {
         let fee_input = {
             let fee_input = self.fee_input_provider.get_batch_fee_input_scaled();
             // In order for execution to pass smoothly, we need to ensure that block's required gasPerPubdata will be
@@ -603,10 +621,13 @@ impl InMemoryNodeInner {
                 .await?;
 
             if result.statistics.pubdata_published > (MAX_VM_PUBDATA_PER_BATCH as u32) {
-                return Err(Web3Error::SubmitTransactionError(
-                    "exceeds limit for published pubdata".into(),
-                    Default::default(),
-                ));
+                return Err(TransactionGasEstimationFailed {
+                    inner: Box::new(gas_estim::ExceedsLimitForPublishedPubdata {
+                        pubdata_published: result.statistics.pubdata_published,
+                        pubdata_limit: (MAX_VM_PUBDATA_PER_BATCH as u32),
+                    }),
+                    transaction_data: tx.raw_bytes.unwrap_or_default().0,
+                });
             }
 
             // It is assumed that there is no overflow here
@@ -686,41 +707,27 @@ impl InMemoryNodeInner {
             VmVersion::latest(),
         ) as u64;
 
-        match &estimate_gas_result.result {
+        let result = match &estimate_gas_result.result {
             ExecutionResult::Revert { output } => {
-                let message = output.to_string();
-                let pretty_message = format!(
-                    "execution reverted{}{}",
-                    if message.is_empty() { "" } else { ": " },
-                    message
-                );
-                let data = output.encoded_data();
-
                 let revert_reason: RevertError = output.clone().to_revert_reason().await;
-                let error_report = ExecutionErrorReport::new(&revert_reason, Some(&tx));
-                sh_println!("{}", error_report);
-
-                Err(Web3Error::SubmitTransactionError(pretty_message, data))
+                Err(gas_estim::TransactionRevert {
+                    inner: Box::new(revert_reason),
+                })
             }
             ExecutionResult::Halt { reason } => {
-                let message = reason.to_string();
-                let pretty_message = format!(
-                    "execution reverted{}{}",
-                    if message.is_empty() { "" } else { ": " },
-                    message
-                );
-
                 let halt_error: HaltError = reason.clone().to_halt_error().await;
-                let error_report = ExecutionErrorReport::new(&halt_error, Some(&tx));
-                sh_println!("{}", error_report);
 
-                Err(Web3Error::SubmitTransactionError(pretty_message, vec![]))
+                Err(gas_estim::TransactionHalt {
+                    inner: Box::new(halt_error),
+                })
             }
             ExecutionResult::Success { .. } => {
                 let full_gas_limit = match suggested_gas_limit.overflowing_add(overhead) {
                     (value, false) => value,
                     (_, true) => {
-                        tracing::info!("Overflow when calculating gas estimation. We've exceeded the block gas limit by summing the following values:");
+                        tracing::info!("
+
+Overflow when calculating gas estimation. We've exceeded the block gas limit by summing the following values:");
                         tracing::info!(
                             "\tEstimated transaction body gas cost: {}",
                             tx_body_gas_limit
@@ -728,10 +735,18 @@ impl InMemoryNodeInner {
                         tracing::info!("\tGas for pubdata: {}", additional_gas_for_pubdata);
                         tracing::info!("\tOverhead: {}", overhead);
 
-                        return Err(Web3Error::SubmitTransactionError(
-                            "exceeds block gas limit".into(),
-                            Default::default(),
-                        ));
+                        return Err(
+                            zksync_error::anvil_zksync::node::TransactionGasEstimationFailed {
+                                inner: Box::new(
+                                    zksync_error::anvil_zksync::gas_estim::ExceedsBlockGasLimit {
+                                        overhead: overhead.into(),
+                                        gas_for_pubdata: additional_gas_for_pubdata.into(),
+                                        estimated_body_cost: tx_body_gas_limit.into(),
+                                    },
+                                ),
+                                transaction_data: tx.raw_bytes.unwrap_or_default().0,
+                            },
+                        );
                     }
                 };
 
@@ -750,6 +765,19 @@ impl InMemoryNodeInner {
                     gas_per_pubdata_limit: gas_per_pubdata_byte.into(),
                 };
                 Ok(fee)
+            }
+        };
+
+        match result {
+            Ok(fee) => Ok(fee),
+            Err(e) => {
+                let error = TransactionGasEstimationFailed {
+                    inner: Box::new(e),
+                    transaction_data: tx.raw_bytes.clone().unwrap_or_default().0,
+                };
+                let error_report = ExecutionErrorReport::new(&error, Some(&tx));
+                sh_println!("{}", error_report);
+                Err(error)
             }
         }
     }
@@ -873,7 +901,7 @@ impl InMemoryNodeInner {
         gas_per_pubdata_byte: u64,
         batch_env: L1BatchEnv,
         system_env: SystemEnv,
-    ) -> Result<VmExecutionResultAndLogs, Web3Error> {
+    ) -> AnvilNodeResult<VmExecutionResultAndLogs> {
         let verbosity = get_shell().verbosity;
         let mut known_addresses = known_addresses_after_transaction(&tx);
         let BatchTransactionExecutionResult {
@@ -893,78 +921,70 @@ impl InMemoryNodeInner {
             true,
         );
 
-        let error = match tx_result.result {
-            ExecutionResult::Success { .. } => {
-                // Transaction is executable with max gas, proceed with gas estimation
-                return Ok(*tx_result);
-            }
-            ExecutionResult::Revert { ref output } => {
-                let message = output.to_string();
-                let pretty_message = format!(
-                    "execution reverted{}{}",
-                    if message.is_empty() { "" } else { ": " },
-                    message
-                );
-                let data = output.encoded_data();
-
-                if verbosity >= 1 {
+        let result: zksync_error::anvil_zksync::node::AnvilNodeResult<()> =
+            match tx_result.result {
+                ExecutionResult::Success { .. } => {
+                    // Transaction is executable with max gas, proceed with gas estimation
+                    Ok(())
+                }
+                ExecutionResult::Revert { ref output } => {
                     let revert_reason: RevertError = output.clone().to_revert_reason().await;
-                    let error_report = ExecutionErrorReport::new(&revert_reason, Some(&tx));
-                    sh_println!(
-                        "{}: {}\n{}",
-                        "error".red().bold(),
-                        "Gas estimation encountered unexecutable transaction".red(),
-                        error_report
-                    );
-                }
 
-                Web3Error::SubmitTransactionError(pretty_message, data)
+                    Err(gas_estim::TransactionRevert {
+                        inner: Box::new(revert_reason),
+                    })
+                }
+                ExecutionResult::Halt { ref reason } => {
+                    let halt_error: HaltError = reason.clone().to_halt_error().await;
+
+                    Err(gas_estim::TransactionHalt {
+                        inner: Box::new(halt_error),
+                    })
+                }
             }
-            ExecutionResult::Halt { ref reason } => {
-                let message = reason.to_string();
-                let pretty_message = format!(
-                    "execution reverted{}{}",
-                    if message.is_empty() { "" } else { ": " },
-                    message
+            .map_err(|inner| AnvilNodeError::TransactionGasEstimationFailed {
+                inner: Box::new(inner),
+                transaction_data: tx.raw_bytes.clone().unwrap_or_default().0,
+            });
+
+        if let Err(error) = result {
+            if verbosity >= 1 {
+                let error_report = ExecutionErrorReport::new(&error, Some(&tx));
+                sh_println!("{error_report}");
+            }
+
+            if !call_traces.is_empty() && verbosity >= 2 {
+                let mut builder = CallTraceDecoderBuilder::default();
+
+                builder = builder.with_signature_identifier(
+                    SignaturesIdentifier::new(
+                        Some(self.config.get_cache_dir().into()),
+                        self.config.offline,
+                    )
+                    .map_err(|err| {
+                        zksync_error::anvil_zksync::node::generic_error!(
+                            "Failed to create SignaturesIdentifier: {err:#}"
+                        )
+                    })?,
                 );
 
-                if verbosity >= 1 {
-                    let halt_error: HaltError = reason.clone().to_halt_error().await;
-                    let error_report = ExecutionErrorReport::new(&halt_error, Some(&tx));
-                    sh_println!(
-                        "{}: {}\n{}",
-                        "error".red().bold(),
-                        "Gas estimation encountered unexecutable transaction".red(),
-                        error_report
-                    );
+                let decoder = builder.build();
+                let mut arena = build_call_trace_arena(&call_traces, &tx_result);
+                decode_trace_arena(&mut arena, &decoder).await;
+
+                extract_addresses(&arena, &mut known_addresses);
+
+                let filtered_arena = filter_call_trace_arena(&arena, verbosity);
+                let trace_output = render_trace_arena_inner(&filtered_arena, false);
+                if !trace_output.is_empty() {
+                    sh_println!("\nTraces:\n{}", trace_output);
                 }
+            };
 
-                Web3Error::SubmitTransactionError(pretty_message, vec![])
-            }
-        };
-
-        if !call_traces.is_empty() && verbosity >= 2 {
-            let mut builder = CallTraceDecoderBuilder::default();
-
-            builder = builder.with_signature_identifier(
-                SignaturesIdentifier::new(
-                    Some(self.config.get_cache_dir().into()),
-                    self.config.offline,
-                )
-                .map_err(|err| anyhow::anyhow!("Failed to create SignaturesIdentifier: {err:#}"))?,
-            );
-
-            let decoder = builder.build();
-            let mut arena = build_call_trace_arena(&call_traces, &tx_result);
-            decode_trace_arena(&mut arena, &decoder).await;
-
-            extract_addresses(&arena, &mut known_addresses);
-
-            let filtered_arena = filter_call_trace_arena(&arena, verbosity);
-            let trace_output = render_trace_arena_inner(&filtered_arena, false);
-            sh_println!("\nTraces:\n{}", trace_output);
+            Err(error)
+        } else {
+            Ok(*tx_result)
         }
-        Err(error)
     }
 
     /// Creates a [Snapshot] of the current state of the node.

--- a/crates/core/src/node/zks.rs
+++ b/crates/core/src/node/zks.rs
@@ -1,6 +1,7 @@
 use crate::node::InMemoryNode;
 use anyhow::Context;
 use std::collections::HashMap;
+use zksync_error::anvil_zksync::node::AnvilNodeResult;
 use zksync_mini_merkle_tree::MiniMerkleTree;
 use zksync_types::api;
 use zksync_types::fee::Fee;
@@ -18,11 +19,11 @@ use zksync_types::{
 use zksync_web3_decl::error::Web3Error;
 
 impl InMemoryNode {
-    pub async fn estimate_fee_impl(&self, req: CallRequest) -> Result<Fee, Web3Error> {
+    pub async fn estimate_fee_impl(&self, req: CallRequest) -> AnvilNodeResult<Fee> {
         self.inner.read().await.estimate_gas_impl(req).await
     }
 
-    pub async fn estimate_gas_l1_to_l2(&self, req: CallRequest) -> Result<U256, Web3Error> {
+    pub async fn estimate_gas_l1_to_l2(&self, req: CallRequest) -> AnvilNodeResult<U256> {
         self.inner
             .read()
             .await

--- a/crates/zksync_error/resources/error-model-dump.json
+++ b/crates/zksync_error/resources/error-model-dump.json
@@ -119,6 +119,20 @@
           }
         }
       },
+      "GasEstimation": {
+        "name": "GasEstimation",
+        "meta": {
+          "description": ""
+        },
+        "bindings": {
+          "rust": {
+            "expression": "Box<GasEstimation>"
+          },
+          "typescript": {
+            "expression": "Box<GasEstimation>"
+          }
+        }
+      },
       "H160": {
         "name": "H160",
         "meta": {
@@ -420,6 +434,7 @@
           "AnvilEnvironment",
           "AnvilGeneric",
           "AnvilNode",
+          "GasEstimation",
           "Halt",
           "Revert",
           "StateLoader",
@@ -623,6 +638,20 @@
         "description": "Errors originating in the ZKsync codebase for Foundry.",
         "origins": [
           "<default zksync-root.json>"
+        ]
+      },
+      "GasEstimation": {
+        "name": "GasEstimation",
+        "code": 5,
+        "domain_name": "AnvilZKsync",
+        "bindings": {
+          "rust": "GasEstimation",
+          "typescript": "GasEstimation"
+        },
+        "identifier": "gas_estim",
+        "description": "",
+        "origins": [
+          "../../etc/errors/anvil.json"
         ]
       },
       "Halt": {
@@ -1027,7 +1056,7 @@
           }
         ],
         "documentation": {
-          "description": "Anvil-zksync starts the server and listens to requests on a specified host and port, 0.0.0.0:8011 by default. They are configurable using `--host` and `--port` command line arguments.\n\nThe host and port used by anvil-zksync are also displayed when you start anvil-zksync:\n\n```\n========================================\nListening on 0.0.0.0:8011\n========================================\n```\n\nThis error indicates that listening on the specified host and port failed.",
+          "description": "Anvil-zksync starts the server and listens to requests on a specified host and port, 0.0.0.0:8011 by default. They are configurable using `--host` and `--port` command line arguments.\n\nThe host and port used by anvil-zksync are also displayed when you start anvil-zksync:\n\n```text\n========================================\nListening on 0.0.0.0:8011\n========================================\n```\n\nThis error indicates that listening on the specified host and port failed.",
           "summary": "Failed to start the server and bind it to the requested host and port.",
           "likely_causes": [
             {
@@ -1058,6 +1087,162 @@
           },
           "typescript": {
             "expression": "ServerStartupFailed"
+          }
+        },
+        "origins": [
+          "../../etc/errors/anvil.json"
+        ]
+      },
+      "[anvil_zksync-gas_estim-0]": {
+        "domain": "AnvilZKsync",
+        "component": "GasEstimation",
+        "name": "GenericError",
+        "code": 0,
+        "identifier": "[anvil_zksync-gas_estim-0]",
+        "message": "Generic error: {message}",
+        "fields": [
+          {
+            "name": "message",
+            "type": "string"
+          }
+        ],
+        "documentation": null,
+        "bindings": {
+          "rust": {
+            "expression": "GenericError"
+          },
+          "typescript": {
+            "expression": "GenericError"
+          }
+        },
+        "origins": []
+      },
+      "[anvil_zksync-gas_estim-10]": {
+        "domain": "AnvilZKsync",
+        "component": "GasEstimation",
+        "name": "TransactionHalt",
+        "code": 10,
+        "identifier": "[anvil_zksync-gas_estim-10]",
+        "message": "Execution halted during the gas estimation:\n{inner}",
+        "fields": [
+          {
+            "name": "inner",
+            "type": "Halt"
+          }
+        ],
+        "documentation": {
+          "description": "This error occurs when anvil-zksync is trying to estimate gas required to run this transaction \nand the transaction is halted due to an error.\nThis is a wrapper error that contains a more specific halt error inside it, which provides details about the cause of the halt.",
+          "summary": "Transaction execution halted while estimating required gas in anvil-zksync.",
+          "likely_causes": []
+        },
+        "bindings": {
+          "rust": {
+            "expression": "TransactionHalt"
+          },
+          "typescript": {
+            "expression": "TransactionHalt"
+          }
+        },
+        "origins": [
+          "../../etc/errors/anvil.json"
+        ]
+      },
+      "[anvil_zksync-gas_estim-11]": {
+        "domain": "AnvilZKsync",
+        "component": "GasEstimation",
+        "name": "TransactionRevert",
+        "code": 11,
+        "identifier": "[anvil_zksync-gas_estim-11]",
+        "message": "Execution reverted during the gas estimation:\n{inner}",
+        "fields": [
+          {
+            "name": "inner",
+            "type": "Revert"
+          }
+        ],
+        "documentation": {
+          "description": "This error occurs when anvil-zksync is trying to estimate gas required to run this transaction \nand the transaction is reverted.\nThis is a wrapper error that contains a more specific halt error inside it, which provides details about the cause of the halt.",
+          "summary": "Transaction execution reverted while estimating required gas in anvil-zksync.",
+          "likely_causes": []
+        },
+        "bindings": {
+          "rust": {
+            "expression": "TransactionRevert"
+          },
+          "typescript": {
+            "expression": "TransactionRevert"
+          }
+        },
+        "origins": [
+          "../../etc/errors/anvil.json"
+        ]
+      },
+      "[anvil_zksync-gas_estim-1]": {
+        "domain": "AnvilZKsync",
+        "component": "GasEstimation",
+        "name": "ExceedsLimitForPublishedPubdata",
+        "code": 1,
+        "identifier": "[anvil_zksync-gas_estim-1]",
+        "message": "Transaction has published {pubdata_published} bytes which exceeds limit for published pubdata ({pubdata_limit}).",
+        "fields": [
+          {
+            "name": "pubdata_published",
+            "type": "uint"
+          },
+          {
+            "name": "pubdata_limit",
+            "type": "uint"
+          }
+        ],
+        "documentation": {
+          "description": "This error occurs when a transaction attempts to publish more pubdata than is allowed in a batch. Each transaction has a limit on how much pubdata it can publish to maintain network efficiency and prevent abuse.",
+          "summary": "Transaction exceeds the limit for published pubdata.",
+          "likely_causes": []
+        },
+        "bindings": {
+          "rust": {
+            "expression": "ExceedsLimitForPublishedPubdata"
+          },
+          "typescript": {
+            "expression": "ExceedsLimitForPublishedPubdata"
+          }
+        },
+        "origins": [
+          "../../etc/errors/anvil.json"
+        ]
+      },
+      "[anvil_zksync-gas_estim-2]": {
+        "domain": "AnvilZKsync",
+        "component": "GasEstimation",
+        "name": "ExceedsBlockGasLimit",
+        "code": 2,
+        "identifier": "[anvil_zksync-gas_estim-2]",
+        "message": "Estimating full gas limit overflows while adding up additional gas ({gas_for_pubdata}), overhead ({overhead}), and estimated transaction body gas cost ({estimated_body_cost}).",
+        "fields": [
+          {
+            "name": "overhead",
+            "type": "u64"
+          },
+          {
+            "name": "gas_for_pubdata",
+            "type": "u64"
+          },
+          {
+            "name": "estimated_body_cost",
+            "type": "u64"
+          }
+        ],
+        "documentation": {
+          "description": "This error occurs when the total gas required for a transaction exceeds the maximum allowed for a block. The total gas is calculated by summing three components: the gas needed for publishing pubdata, the fixed overhead costs, and the estimated gas for the transaction body itself. When this sum overflows or exceeds the block limit, this error is thrown.",
+          "summary": "Transaction gas estimation exceeds the block gas limit.",
+          "likely_causes": []
+        },
+        "bindings": {
+          "rust": {
+            "expression": "ExceedsBlockGasLimit"
+          },
+          "typescript": {
+            "expression": "ExceedsBlockGasLimit"
           }
         },
         "origins": [
@@ -1998,7 +2183,7 @@
         "name": "TransactionValidationFailed",
         "code": 10,
         "identifier": "[anvil_zksync-node-10]",
-        "message": "Transaction {transaction_hash}: validation failed. Reason: {inner}",
+        "message": "Transaction {transaction_hash}: validation failed: {inner}",
         "fields": [
           {
             "name": "inner",
@@ -2010,7 +2195,7 @@
           }
         ],
         "documentation": {
-          "description": "This error occurs when a transaction validation is failed and it is not executed.\nThis is a wrapper error that contains a more specific validation error inside it, which provides details about the cause of the halt.\n\nThe validation may for various reasons including:\n- Gas limit exceedance\n- Invalid gas limit value\n- maxFeePerGas exceeding maxPriorityFeePerGas, and so on.\n\nWhen using anvil-zksync for testing, these errors are valuable signals that help you identify issues with your contracts or transactions before deploying to the real ZKSync network.",
+          "description": "This error occurs when a transaction validation is failed and it is not executed.\nThis is a wrapper error that contains a more specific validation error inside it, which provides details about the cause of the halt.\n\nThe validation may fail for various reasons including:\n- Gas limit exceedance\n- Invalid gas limit value\n- maxFeePerGas exceeding maxPriorityFeePerGas, and so on.\n\nWhen using anvil-zksync for testing, these errors are valuable signals that help you identify issues with your contracts or transactions before deploying to the real ZKSync network.",
           "summary": "Transaction validation failed in anvil-zksync.",
           "likely_causes": []
         },
@@ -2026,13 +2211,85 @@
           "../../etc/errors/anvil.json"
         ]
       },
+      "[anvil_zksync-node-11]": {
+        "domain": "AnvilZKsync",
+        "component": "AnvilNode",
+        "name": "TransactionGasEstimationFailed",
+        "code": 11,
+        "identifier": "[anvil_zksync-node-11]",
+        "message": "Gas estimation failed: \n{inner}",
+        "fields": [
+          {
+            "name": "inner",
+            "type": "GasEstimation"
+          },
+          {
+            "name": "transaction_data",
+            "type": "bytes"
+          }
+        ],
+        "documentation": {
+          "description": "This error occurs when a gas estimation for transaction failed.\nThis is a wrapper error that contains a more specific gas estimation error inside it, which provides details about the cause of failure.",
+          "summary": "Transaction gas estimation failed in anvil-zksync.",
+          "likely_causes": [
+            {
+              "cause": "The transaction always reverts, so it can't be estimated.",
+              "fixes": [
+                "Inspect the source code of your contracts and debug the transaction to eliminate the cause of revert."
+              ],
+              "report": "",
+              "owner": null,
+              "references": []
+            },
+            {
+              "cause": "The transaction always halts, so it can't be estimated.",
+              "fixes": [
+                "Inspect the source code of your contracts and debug the transaction to eliminate the cause of halt."
+              ],
+              "report": "",
+              "owner": null,
+              "references": []
+            },
+            {
+              "cause": "The transaction requires too much gas to be executed. For example, it may contain an infinite loop.",
+              "fixes": [
+                "Debug the transaction to see why it consumes more gas than is allowed."
+              ],
+              "report": "",
+              "owner": null,
+              "references": []
+            },
+            {
+              "cause": "The transaction is malformed",
+              "fixes": [
+                "Check the nonce value provided in the RPC call that you are using (such as `eth_estimateGas`). If you do not care about the specific nonce for the transaction, do not provide any value for it.",
+                "Check all arguments of the RPC call (such as `eth_estimateGas`). Are the `from`, `to` addresses correct?"
+              ],
+              "report": "",
+              "owner": null,
+              "references": []
+            }
+          ]
+        },
+        "bindings": {
+          "rust": {
+            "expression": "TransactionGasEstimationFailed"
+          },
+          "typescript": {
+            "expression": "TransactionGasEstimationFailed"
+          }
+        },
+        "origins": [
+          "../../etc/errors/anvil.json"
+        ]
+      },
       "[anvil_zksync-node-1]": {
         "domain": "AnvilZKsync",
         "component": "AnvilNode",
         "name": "TransactionHalt",
         "code": 1,
         "identifier": "[anvil_zksync-node-1]",
-        "message": "Transaction {transaction_hash} execution halted, reason: {inner}",
+        "message": "Transaction {transaction_hash} execution halted:\n{inner}",
         "fields": [
           {
             "name": "inner",
@@ -2170,6 +2427,75 @@
           },
           "typescript": {
             "expression": "TimestampBackwardsError"
+          }
+        },
+        "origins": [
+          "../../etc/errors/anvil.json"
+        ]
+      },
+      "[anvil_zksync-node-30]": {
+        "domain": "AnvilZKsync",
+        "component": "AnvilNode",
+        "name": "SerializationError",
+        "code": 30,
+        "identifier": "[anvil_zksync-node-30]",
+        "message": "Failed to parse L1 transaction from request (from={from}, to={to}): {reason}.",
+        "fields": [
+          {
+            "name": "from",
+            "type": "H256"
+          },
+          {
+            "name": "to",
+            "type": "H256"
+          },
+          {
+            "name": "reason",
+            "type": "string"
+          }
+        ],
+        "documentation": {
+          "description": "This error occurs when anvil-zksync is unable to convert a transaction request into a properly formatted transaction object.\nThis typically happens during transaction creation or gas estimation when the request contains invalid or incompatible parameters.",
+          "summary": "Failed to serialize transaction request into a valid transaction.",
+          "likely_causes": [
+            {
+              "cause": "Malformed transaction data in the request.",
+              "fixes": [
+                "Verify that all transaction parameters are properly formatted and have valid values.",
+                "Check that addresses are valid Ethereum addresses.",
+                "Ensure that numeric values are within their allowed ranges."
+              ],
+              "report": "",
+              "owner": null,
+              "references": []
+            },
+            {
+              "cause": "Missing required transaction fields.",
+              "fixes": [
+                "Make sure all required fields for the transaction type are included in the request."
+              ],
+              "report": "",
+              "owner": null,
+              "references": []
+            },
+            {
+              "cause": "Incompatible transaction parameters.",
+              "fixes": [
+                "Check that the combination of parameters is valid for the transaction type being used.",
+                "Verify that gas-related parameters are consistent with each other."
+              ],
+              "report": "",
+              "owner": null,
+              "references": []
+            }
+          ]
+        },
+        "bindings": {
+          "rust": {
+            "expression": "SerializationError"
+          },
+          "typescript": {
+            "expression": "SerializationError"
           }
         },
         "origins": [
@@ -2600,7 +2926,7 @@
         "name": "StateFileAccess",
         "code": 6,
         "identifier": "[anvil_zksync-state-6]",
-        "message": "Error while accessing the state located at `{path}`. Reason: {reason}.",
+        "message": "Error while accessing the state located at `{path}`: {reason}.",
         "fields": [
           {
             "name": "path",

--- a/crates/zksync_error/src/error/domains.rs
+++ b/crates/zksync_error/src/error/domains.rs
@@ -17,6 +17,8 @@ use crate::error::definitions::FoundryUpstream;
 use crate::error::definitions::FoundryUpstreamCode;
 use crate::error::definitions::FoundryZksync;
 use crate::error::definitions::FoundryZksyncCode;
+use crate::error::definitions::GasEstimation;
+use crate::error::definitions::GasEstimationCode;
 use crate::error::definitions::Halt;
 use crate::error::definitions::HaltCode;
 use crate::error::definitions::HardhatUpstream;
@@ -105,6 +107,9 @@ impl ZksyncError {
             ZksyncError::AnvilZksync(AnvilZksync::AnvilNode(_)) => {
                 Kind::AnvilZksync(AnvilZksyncCode::AnvilNode)
             }
+            ZksyncError::AnvilZksync(AnvilZksync::GasEstimation(_)) => {
+                Kind::AnvilZksync(AnvilZksyncCode::GasEstimation)
+            }
             ZksyncError::AnvilZksync(AnvilZksync::Halt(_)) => {
                 Kind::AnvilZksync(AnvilZksyncCode::Halt)
             }
@@ -153,6 +158,9 @@ impl ZksyncError {
             }
             ZksyncError::AnvilZksync(AnvilZksync::AnvilNode(error)) => {
                 Into::<AnvilNodeCode>::into(error) as u32
+            }
+            ZksyncError::AnvilZksync(AnvilZksync::GasEstimation(error)) => {
+                Into::<GasEstimationCode>::into(error) as u32
             }
             ZksyncError::AnvilZksync(AnvilZksync::Halt(error)) => {
                 Into::<HaltCode>::into(error) as u32
@@ -223,6 +231,7 @@ pub enum AnvilZksync {
     AnvilEnvironment(AnvilEnvironment),
     AnvilGeneric(AnvilGeneric),
     AnvilNode(AnvilNode),
+    GasEstimation(GasEstimation),
     Halt(Halt),
     Revert(Revert),
     StateLoader(StateLoader),
@@ -261,6 +270,16 @@ impl ICustomError<ZksyncError, ZksyncError> for AnvilNode {
 impl From<AnvilNode> for AnvilZksync {
     fn from(val: AnvilNode) -> Self {
         AnvilZksync::AnvilNode(val)
+    }
+}
+impl ICustomError<ZksyncError, ZksyncError> for GasEstimation {
+    fn to_unified(&self) -> ZksyncError {
+        AnvilZksync::GasEstimation(self.clone()).to_unified()
+    }
+}
+impl From<GasEstimation> for AnvilZksync {
+    fn from(val: GasEstimation) -> Self {
+        AnvilZksync::GasEstimation(val)
     }
 }
 impl ICustomError<ZksyncError, ZksyncError> for Halt {
@@ -322,6 +341,7 @@ impl crate::documentation::Documented for AnvilZksync {
             AnvilZksync::AnvilEnvironment(error) => error.get_documentation(),
             AnvilZksync::AnvilGeneric(error) => error.get_documentation(),
             AnvilZksync::AnvilNode(error) => error.get_documentation(),
+            AnvilZksync::GasEstimation(error) => error.get_documentation(),
             AnvilZksync::Halt(error) => error.get_documentation(),
             AnvilZksync::Revert(error) => error.get_documentation(),
             AnvilZksync::StateLoader(error) => error.get_documentation(),
@@ -335,6 +355,7 @@ impl std::fmt::Display for AnvilZksync {
             AnvilZksync::AnvilEnvironment(component) => component.fmt(f),
             AnvilZksync::AnvilGeneric(component) => component.fmt(f),
             AnvilZksync::AnvilNode(component) => component.fmt(f),
+            AnvilZksync::GasEstimation(component) => component.fmt(f),
             AnvilZksync::Halt(component) => component.fmt(f),
             AnvilZksync::Revert(component) => component.fmt(f),
             AnvilZksync::StateLoader(component) => component.fmt(f),

--- a/crates/zksync_error/src/error/mod.rs
+++ b/crates/zksync_error/src/error/mod.rs
@@ -50,6 +50,7 @@ impl IError<ZksyncError> for ZksyncError {
             ZksyncError::AnvilZksync(AnvilZksync::AnvilEnvironment(error)) => error.get_message(),
             ZksyncError::AnvilZksync(AnvilZksync::AnvilGeneric(error)) => error.get_message(),
             ZksyncError::AnvilZksync(AnvilZksync::AnvilNode(error)) => error.get_message(),
+            ZksyncError::AnvilZksync(AnvilZksync::GasEstimation(error)) => error.get_message(),
             ZksyncError::AnvilZksync(AnvilZksync::Halt(error)) => error.get_message(),
             ZksyncError::AnvilZksync(AnvilZksync::Revert(error)) => error.get_message(),
             ZksyncError::AnvilZksync(AnvilZksync::StateLoader(error)) => error.get_message(),

--- a/crates/zksync_error/src/identifier.rs
+++ b/crates/zksync_error/src/identifier.rs
@@ -80,6 +80,7 @@ impl Identifying for Kind {
             Kind::AnvilZksync(AnvilZksyncCode::AnvilEnvironment) => "anvil_zksync-env",
             Kind::AnvilZksync(AnvilZksyncCode::AnvilGeneric) => "anvil_zksync-gen",
             Kind::AnvilZksync(AnvilZksyncCode::AnvilNode) => "anvil_zksync-node",
+            Kind::AnvilZksync(AnvilZksyncCode::GasEstimation) => "anvil_zksync-gas_estim",
             Kind::AnvilZksync(AnvilZksyncCode::Halt) => "anvil_zksync-halt",
             Kind::AnvilZksync(AnvilZksyncCode::Revert) => "anvil_zksync-revert",
             Kind::AnvilZksync(AnvilZksyncCode::StateLoader) => "anvil_zksync-state",
@@ -117,6 +118,11 @@ impl NamedError for Identifier {
             }
             Kind::AnvilZksync(AnvilZksyncCode::AnvilNode) => {
                 crate::error::definitions::AnvilNodeCode::from_repr(self.code)
+                    .expect("Internal error")
+                    .get_error_name()
+            }
+            Kind::AnvilZksync(AnvilZksyncCode::GasEstimation) => {
+                crate::error::definitions::GasEstimationCode::from_repr(self.code)
                     .expect("Internal error")
                     .get_error_name()
             }

--- a/crates/zksync_error/src/lib.rs
+++ b/crates/zksync_error/src/lib.rs
@@ -69,7 +69,9 @@ pub mod anvil_zksync {
         pub use crate::error::definitions::AnvilNode as AnvilNodeError;
         pub type AnvilNodeResult<T> = core::result::Result<T, AnvilNodeError>;
         pub use crate::error::definitions::AnvilNode::GenericError;
+        pub use crate::error::definitions::AnvilNode::SerializationError;
         pub use crate::error::definitions::AnvilNode::TimestampBackwardsError;
+        pub use crate::error::definitions::AnvilNode::TransactionGasEstimationFailed;
         pub use crate::error::definitions::AnvilNode::TransactionHalt;
         pub use crate::error::definitions::AnvilNode::TransactionValidationFailed;
         pub use crate::error::definitions::AnvilNodeCode as ErrorCode;
@@ -83,6 +85,29 @@ pub mod anvil_zksync {
         }
         pub fn to_domain<T: std::fmt::Display>(err: T) -> super::AnvilZksyncError {
             super::AnvilZksyncError::AnvilNode(GenericError {
+                message: err.to_string(),
+            })
+        }
+    }
+    pub mod gas_estim {
+        pub use crate::error::definitions::GasEstimation as GasEstimationError;
+        pub type GasEstimationResult<T> = core::result::Result<T, GasEstimationError>;
+        pub use crate::error::definitions::GasEstimation::ExceedsBlockGasLimit;
+        pub use crate::error::definitions::GasEstimation::ExceedsLimitForPublishedPubdata;
+        pub use crate::error::definitions::GasEstimation::GenericError;
+        pub use crate::error::definitions::GasEstimation::TransactionHalt;
+        pub use crate::error::definitions::GasEstimation::TransactionRevert;
+        pub use crate::error::definitions::GasEstimationCode as ErrorCode;
+        #[macro_export]
+        macro_rules ! anvil_zksync_gas_estim_generic_error { ($ ($ arg : tt) *) => { zksync_error :: anvil_zksync :: gas_estim :: GasEstimationError :: GenericError { message : format ! ($ ($ arg) *) } } ; }
+        pub use crate::anvil_zksync_gas_estim_generic_error as generic_error;
+        pub fn to_generic<T: std::fmt::Display>(err: T) -> GasEstimationError {
+            GenericError {
+                message: err.to_string(),
+            }
+        }
+        pub fn to_domain<T: std::fmt::Display>(err: T) -> super::AnvilZksyncError {
+            super::AnvilZksyncError::GasEstimation(GenericError {
                 message: err.to_string(),
             })
         }

--- a/etc/errors/anvil.json
+++ b/etc/errors/anvil.json
@@ -1049,7 +1049,7 @@
                   "This error occurs when a transaction validation is failed and it is not executed.",
                   "This is a wrapper error that contains a more specific validation error inside it, which provides details about the cause of the halt.",
                   "",
-                  "The validation may for various reasons including:",
+                  "The validation may fail for various reasons including:",
                   "- Gas limit exceedance",
                   "- Invalid gas limit value",
                   "- maxFeePerGas exceeding maxPriorityFeePerGas, and so on.",

--- a/etc/errors/anvil.json
+++ b/etc/errors/anvil.json
@@ -72,7 +72,7 @@
                   "",
                   "The host and port used by anvil-zksync are also displayed when you start anvil-zksync:",
                   "",
-                  "```",
+                  "```text",
                   "========================================",
                   "Listening on 0.0.0.0:8011",
                   "========================================",
@@ -118,7 +118,7 @@
                   "Anvil-zksync was unable to open log file for writing.",
                   "By default, the log file is searched for at `./anvil-zksync.log`.",
                   "You may provide this path explicitly through the CLI argument `--log-file-path`."
-                  ],
+                ],
                 "likely_causes": [
                   {
                     "cause": "Wrong path to log file.",
@@ -191,7 +191,7 @@
           ]
         },
         {
-        "component_name": "Halt",
+          "component_name": "Halt",
           "component_code": 2,
           "identifier_encoding": "halt",
           "errors": [
@@ -213,7 +213,7 @@
                 "summary": "Account validation failed during execution.",
                 "description": "This error occurs when the account validation step fails during the verification and execution of a transaction.",
                 "likely_causes": [
-                    {
+                  {
                     "cause": "Insufficient funds to cover transaction costs.",
                     "fixes": [
                       "Add enough balance to the account to pay for gas and the transaction amount."
@@ -303,13 +303,13 @@
                 "summary": "Payment for the transaction failed.",
                 "description": "This error is emitted when the system fails to deduct the required fees for executing the transaction.",
                 "likely_causes": [
-                   {
-                      "cause": "Insufficient funds to cover the transaction fee.",
-                      "fixes": [
-                        "Ensure the account balance is sufficient to cover the fee (maxFeePerGas * gasLimit)."
-                      ]
-                    },
-                    {
+                  {
+                    "cause": "Insufficient funds to cover the transaction fee.",
+                    "fixes": [
+                      "Ensure the account balance is sufficient to cover the fee (maxFeePerGas * gasLimit)."
+                    ]
+                  },
+                  {
                     "cause": "Incorrect transaction fee configuration (maxFeePerGas or gasLimit).",
                     "fixes": [
                       "Verify that the maxFeePerGas and gasLimit values are correctly set to reflect the intended fee, and ensure they are within the limits of the account's balance."
@@ -386,7 +386,7 @@
                 "summary": "The sender address is not a valid account.",
                 "description": "This error occurs when a transaction is attempted from an address that has not been deployed as an account, meaning the `from` address is just a contract.",
                 "likely_causes": [
-                   {
+                  {
                     "cause": "Account not deployed with `createAccount` or `create2Account`",
                     "fixes": [
                       "Ensure that the `from` address is an account deployed using `createAccount` or `create2Account`."
@@ -439,7 +439,7 @@
                 ]
               }
             },
-           {
+            {
               "name": "UnexpectedVMBehavior",
               "code": 10,
               "message": "Virtual machine entered unexpected state. Error description: {problem}",
@@ -764,7 +764,7 @@
                 "summary": "An unknown VM revert reason was encountered.",
                 "description": "This error is emitted when the VM encounters a revert reason that is not recognized. In most cases, this error may also indicate that the transaction exhausted all the gas allocated for its execution.",
                 "likely_causes": [
-                   {
+                  {
                     "cause": "The transaction exhausted all the gas allocated for execution.",
                     "fixes": [
                       "Increase the gas limit and verify that the contract logic is optimized. Review gas usage."
@@ -957,6 +957,93 @@
           ]
         },
         {
+          "component_name": "GasEstimation",
+          "component_code": 5,
+          "identifier_encoding": "gas_estim",
+          "errors" : [
+            {
+              "name": "ExceedsLimitForPublishedPubdata",
+              "code": 1,
+              "message": "Transaction has published {pubdata_published} bytes which exceeds limit for published pubdata ({pubdata_limit}).",
+              "fields": [
+                {
+                  "name":"pubdata_published",
+                  "type":"uint"
+                },
+                {
+                  "name":"pubdata_limit",
+                  "type":"uint"
+                }
+              ],
+              "doc" : {
+                "summary": "Transaction exceeds the limit for published pubdata.",
+                "description": "This error occurs when a transaction attempts to publish more pubdata than is allowed in a batch. Each transaction has a limit on how much pubdata it can publish to maintain network efficiency and prevent abuse."
+              }
+            },
+            {
+              "name": "ExceedsBlockGasLimit",
+              "code": 2,
+              "message": "Estimating full gas limit overflows while adding up additional gas ({gas_for_pubdata}), overhead ({overhead}), and estimated transaction body gas cost ({estimated_body_cost}).",
+              "fields": [
+                {
+                  "name":"overhead",
+                  "type":"u64"
+                },
+                {
+                  "name":"gas_for_pubdata",
+                  "type":"u64"
+                },
+                {
+                  "name":"estimated_body_cost",
+                  "type":"u64"
+                }
+              ],
+              "doc": {
+                "summary": "Transaction gas estimation exceeds the block gas limit.",
+                "description": "This error occurs when the total gas required for a transaction exceeds the maximum allowed for a block. The total gas is calculated by summing three components: the gas needed for publishing pubdata, the fixed overhead costs, and the estimated gas for the transaction body itself. When this sum overflows or exceeds the block limit, this error is thrown."
+              }
+            },
+            {
+              "name": "TransactionHalt",
+              "code": 10,
+              "message": "Execution halted during the gas estimation:\n{inner}",
+              "fields": [
+                {
+                  "name": "inner",
+                  "type": "Halt"
+                }
+              ],
+              "doc": {
+                "summary": "Transaction execution halted while estimating required gas in anvil-zksync.",
+                "description": [
+                  "This error occurs when anvil-zksync is trying to estimate gas required to run this transaction ",
+                  "and the transaction is halted due to an error.",
+                  "This is a wrapper error that contains a more specific halt error inside it, which provides details about the cause of the halt."
+                ]
+              }
+            },
+            {
+              "name": "TransactionRevert",
+              "code": 11,
+              "message": "Execution reverted during the gas estimation:\n{inner}",
+              "fields": [
+                {
+                  "name": "inner",
+                  "type": "Revert"
+                }
+              ],
+              "doc": {
+                "summary": "Transaction execution reverted while estimating required gas in anvil-zksync.",
+                "description": [
+                  "This error occurs when anvil-zksync is trying to estimate gas required to run this transaction ",
+                  "and the transaction is reverted.",
+                  "This is a wrapper error that contains a more specific halt error inside it, which provides details about the cause of the halt."
+                ]
+              }
+            }
+          ]
+        },
+        {
           "component_name": "AnvilNode",
           "component_code": 10,
           "identifier_encoding": "node",
@@ -964,7 +1051,7 @@
             {
               "name": "TransactionHalt",
               "code": 1,
-              "message": "Transaction {transaction_hash} execution halted, reason: {inner}",
+              "message": "Transaction {transaction_hash} execution halted:\n{inner}",
               "fields": [
                 {
                   "name": "inner",
@@ -1032,7 +1119,7 @@
             {
               "name": "TransactionValidationFailed",
               "code": 10,
-              "message": "Transaction {transaction_hash}: validation failed. Reason: {inner}",
+              "message": "Transaction {transaction_hash}: validation failed: {inner}",
               "fields": [
                 {
                   "name": "inner",
@@ -1055,6 +1142,55 @@
                   "- maxFeePerGas exceeding maxPriorityFeePerGas, and so on.",
                   "",
                   "When using anvil-zksync for testing, these errors are valuable signals that help you identify issues with your contracts or transactions before deploying to the real ZKSync network."
+                ]
+              }
+            },
+            {
+              "name": "TransactionGasEstimationFailed",
+              "code": 11,
+              "message": "Gas estimation failed: \n{inner}",
+              "fields": [
+                {
+                  "name": "inner",
+                  "type": "GasEstimation"
+                },
+                {
+                  "name": "transaction_data",
+                  "type": "bytes"
+                }
+              ],
+              "doc": {
+                "summary": "Transaction gas estimation failed in anvil-zksync.",
+                "description": [
+                  "This error occurs when a gas estimation for transaction failed.",
+                  "This is a wrapper error that contains a more specific gas estimation error inside it, which provides details about the cause of failure."
+                ],
+                "likely_causes": [
+                  {
+                    "cause": "The transaction always reverts, so it can't be estimated.",
+                    "fixes": [
+                      "Inspect the source code of your contracts and debug the transaction to eliminate the cause of revert."
+                    ]
+                  },
+                  {
+                    "cause": "The transaction always halts, so it can't be estimated.",
+                    "fixes": [
+                      "Inspect the source code of your contracts and debug the transaction to eliminate the cause of halt."
+                    ]
+                  },
+                  {
+                    "cause": "The transaction requires too much gas to be executed. For example, it may contain an infinite loop.",
+                    "fixes": [
+                      "Debug the transaction to see why it consumes more gas than is allowed."
+                    ]
+                  },
+                  {
+                    "cause": "The transaction is malformed",
+                    "fixes": [
+                      "Check the nonce value provided in the RPC call that you are using (such as `eth_estimateGas`). If you do not care about the specific nonce for the transaction, do not provide any value for it.",
+                      "Check all arguments of the RPC call (such as `eth_estimateGas`). Are the `from`, `to` addresses correct?"
+                    ]
+                  }
                 ]
               }
             },
@@ -1115,7 +1251,57 @@
                   }
                 ]
               }
+            },
+            {
+              "name": "SerializationError",
+              "code": 30,
+              "message": "Failed to parse L1 transaction from request (from={from}, to={to}): {reason}.",
+              "fields": [
+                {
+                  "name": "from",
+                  "type": "H256"
+                },
+                {
+                  "name": "to",
+                  "type": "H256"
+                },
+                {
+                  "name": "reason",
+                  "type": "string"
+                }
+              ],
+              "doc": {
+                "summary": "Failed to serialize transaction request into a valid transaction.",
+                "description": [
+                  "This error occurs when anvil-zksync is unable to convert a transaction request into a properly formatted transaction object.",
+                  "This typically happens during transaction creation or gas estimation when the request contains invalid or incompatible parameters."
+                ],
+                "likely_causes": [
+                  {
+                    "cause": "Malformed transaction data in the request.",
+                    "fixes": [
+                      "Verify that all transaction parameters are properly formatted and have valid values.",
+                      "Check that addresses are valid Ethereum addresses.",
+                      "Ensure that numeric values are within their allowed ranges."
+                    ]
+                  },
+                  {
+                    "cause": "Missing required transaction fields.",
+                    "fixes": [
+                      "Make sure all required fields for the transaction type are included in the request."
+                    ]
+                  },
+                  {
+                    "cause": "Incompatible transaction parameters.",
+                    "fixes": [
+                      "Check that the combination of parameters is valid for the transaction type being used.",
+                      "Verify that gas-related parameters are consistent with each other."
+                    ]
+                  }
+                ]
+              }
             }
+
           ]
         },
         {
@@ -1202,7 +1388,7 @@
             {
               "name": "StateFileAccess",
               "code": 6,
-              "message": "Error while accessing the state located at `{path}`. Reason: {reason}.",
+              "message": "Error while accessing the state located at `{path}`: {reason}.",
               "fields": [
                 {
                   "name": "path",


### PR DESCRIPTION
# What :computer: 
* Reverted or halted transactions during gas estimation are properly reported
* Added new error types for gas estimation errors

# Why :hand:
* Fixes https://github.com/matter-labs/anvil-zksync/issues/675


# Evidence :camera:

## Source

```solidity

```


```sh
PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
RPC_URL=http://127.0.0.1:8011

CONTRACT_ADDRESS=$(forge create --rpc-url $RPC_URL \
    --chain 260 \
    --zksync \
  --private-key $PRIVATE_KEY \
  src/SampleGas.sol:SampleGas \
  | grep "Deployed to" | awk '{print $3}')

echo "Contract deployed at: $CONTRACT_ADDRESS"

FROM_ADDRESS=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
RPC_URL=http://127.0.0.1:8011

curl -s --request POST --url $RPC_URL \
  --header 'content-type: application/json' \
  --data '{
    "jsonrpc": "2.0",
      "id": "2",
      "method": "eth_estimateGas",
      "params": [{
          "to": "'$CONTRACT_ADDRESS'",
          "data": "'$(cast calldata "loop()")'",
          "from": "'$FROM_ADDRESS'",
          "gas": "0x0000",
          "gasPrice": "0x0000",
          "value": "0x0000"
      }, "latest"]
  }'

>>  
 {
  "jsonrpc": "2.0",
  "id": "2",
  "error": {
    "code": 3,
    "message": "[anvil_zksync-node-11] Gas estimation failed: \n[anvil_zksync-gas_estim-11] Execution reverted during the gas estimation:\n[anvil_zksync-revert-4] Unknown VM revert reason: function_selector=Error: no function selector available, data=",
    "data": "0x"
  }
}
```
 
## anvil-zksync output

```
error: [anvil_zksync-node-11] Gas estimation failed:
[anvil_zksync-gas_estim-10] Execution halted during the gas estimation:
[anvil_zksync-halt-1] Account validation error: 0xe90aded4: e90aded4000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb922660000000000000000000000000000000000000000000000000000000000000000
    |
    = error: Transaction gas estimation failed in anvil-zksync.
    |
    | Transaction details:
    |   Transaction Type: LegacyTransaction
    |   Nonce: 0
    |   To: 0x588758d8a0ad1162a6294f3c274753137e664ae3
    |   From: 0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266
    |   Gas Limit: 0
    |   Gas Price: 0.045250 gwei
    |   Gas Per Pubdata Limit: 50000
    |
    | Likely causes:
    |   - The transaction always reverts, so it can't be estimated.
    |   - The transaction always halts, so it can't be estimated.
    |   - The transaction requires too much gas to be executed. For example, it may contain an infinite loop.
    |   - The transaction is malformed
    |
    | Possible fixes:
    |   - Inspect the source code of your contracts and debug the transaction to eliminate the cause of revert.
    |   - Inspect the source code of your contracts and debug the transaction to eliminate the cause of halt.
    |   - Debug the transaction to see why it consumes more gas than is allowed.
    |   - Check the nonce value provided in the RPC call that you are using (such as `eth_estimateGas`). If you do not care about the specific nonce for the transaction, do not provide any value for it.
    |   - Check all arguments of the RPC call (such as `eth_estimateGas`). Are the `from`, `to` addresses correct?
    |
note: This error occurs when a gas estimation for transaction failed.
This is a wrapper error that contains a more specific gas estimation error inside it, which provides details about the cause of failure.
error: transaction execution halted due to the above error

```