### PR TITLE
feat: increase max transaction size

### DIFF
--- a/crates/core/src/node/in_memory.rs
+++ b/crates/core/src/node/in_memory.rs
@@ -77,7 +77,9 @@ use zksync_types::{
 };
 
 /// Max possible size of an ABI encoded tx (in bytes).
-pub const MAX_TX_SIZE: usize = 1_000_000;
+/// NOTE: this deviates slightly from the default value in the main node config,
+/// that being `api.max_tx_size = 1_000_000`.
+pub const MAX_TX_SIZE: usize = 1_200_000;
 /// Acceptable gas overestimation limit.
 pub const ESTIMATE_GAS_ACCEPTABLE_OVERESTIMATION: u64 = 1_000;
 /// The maximum number of previous blocks to store the state for.


### PR DESCRIPTION
# What :computer: 

Increases `MAX_TX_SIZE` from `1_000_000` to `1_200_000`

# Why :hand:

Needed to support certain blob unit tests in era-contracts, now that max number of blobs is 9.


