### PR TITLE
fix: revert reasons not communicated to hardhat

### DIFF
--- a/crates/core/src/formatter/errors/view.rs
+++ b/crates/core/src/formatter/errors/view.rs
@@ -156,8 +156,8 @@ impl PrettyFmt for EstimationErrorReport<'_> {
                 writeln!(w, "{}", DescriptionView(self.error))?;
             }
 
-            GasEstimationError::TransactionRevert { inner }
-            | GasEstimationError::TransactionAlwaysReverts { inner } => {
+            GasEstimationError::TransactionRevert { inner, data: _ }
+            | GasEstimationError::TransactionAlwaysReverts { inner, data: _ } => {
                 let revert = inner.as_ref();
                 writeln!(w, "{}", ErrorMessageView(self.error))?;
                 let mut w = IndentingWriter::new(w, Some("│ "));

--- a/crates/core/src/node/inner/in_memory_inner.rs
+++ b/crates/core/src/node/inner/in_memory_inner.rs
@@ -714,6 +714,7 @@ impl InMemoryNodeInner {
                 let revert_reason: RevertError = output.clone().to_revert_reason().await;
                 Err(gas_estim::TransactionRevert {
                     inner: Box::new(revert_reason),
+                    data: output.encoded_data(),
                 })
             }
             ExecutionResult::Halt { reason } => {
@@ -921,6 +922,7 @@ impl InMemoryNodeInner {
 
                     Err(gas_estim::TransactionAlwaysReverts {
                         inner: Box::new(revert_reason),
+                        data: output.encoded_data(),
                     })
                 }
                 ExecutionResult::Halt { ref reason } => {

--- a/crates/zksync_error/resources/error-model-dump.json
+++ b/crates/zksync_error/resources/error-model-dump.json
@@ -1168,6 +1168,10 @@
           {
             "name": "inner",
             "type": "Revert"
+          },
+          {
+            "name": "data",
+            "type": "bytes"
           }
         ],
         "documentation": {
@@ -1313,6 +1317,10 @@
           {
             "name": "inner",
             "type": "Revert"
+          },
+          {
+            "name": "data",
+            "type": "bytes"
           }
         ],
         "documentation": {

--- a/crates/zksync_error/src/error/definitions.rs
+++ b/crates/zksync_error/src/error/definitions.rs
@@ -498,6 +498,7 @@ pub enum GasEstimation {
     #[doc = "Typically they depend on specific gas values, for example, they revert if `gasleft()` returned a value in a specific range."]
     TransactionRevert {
         inner: Box<Revert>,
+        data: Vec<u8>,
     } = 11u32,
     #[doc = "# Summary "]
     #[doc = "An attempt to run the transaction with maximum gas resulted in reverting the transaction and burning all gas."]
@@ -526,6 +527,7 @@ pub enum GasEstimation {
     #[doc = "Usually, this error indicates either an unconditional revert or excessive gas consumption."]
     TransactionAlwaysReverts {
         inner: Box<Revert>,
+        data: Vec<u8>,
     } = 21u32,
     GenericError {
         message: String,
@@ -596,13 +598,13 @@ impl CustomErrorMessage for GasEstimation {
             GasEstimation::TransactionHalt { inner } => {
                 format ! ("[anvil_zksync-gas_estim-10] Gas estimation failed because the transaction exhibits exotic gas behavior and reverts, burning all gas: {inner}")
             }
-            GasEstimation::TransactionRevert { inner } => {
+            GasEstimation::TransactionRevert { inner, data } => {
                 format ! ("[anvil_zksync-gas_estim-11] Gas estimation failed because the transaction exhibits exotic gas behavior and reverts, returning unspent gas: {inner}")
             }
             GasEstimation::TransactionAlwaysHalts { inner } => {
                 format ! ("[anvil_zksync-gas_estim-20] Gas estimation is impossible because the transaction can not be executed with maximum gas, it reverts and returns unspent gas:\n{inner}")
             }
-            GasEstimation::TransactionAlwaysReverts { inner } => {
+            GasEstimation::TransactionAlwaysReverts { inner, data } => {
                 format ! ("[anvil_zksync-gas_estim-21] Gas estimation is impossible because the transaction can not be executed with maximum gas, it reverts and burns all gas:\n{inner}")
             }
             GasEstimation::GenericError { message } => {

--- a/e2e-tests-rust/src/ext.rs
+++ b/e2e-tests-rust/src/ext.rs
@@ -66,6 +66,18 @@ pub trait ReceiptExt: ReceiptResponse {
         }
         Ok(())
     }
+
+    /// Asserts that receipt is successful.
+    fn assert_reverted(&self, msg: &str) -> anyhow::Result<()> {
+        if self.status() {
+            anyhow::bail!(
+                "receipt (hash={}, block={:?}) is successful",
+                self.transaction_hash(),
+                self.block_number(),
+            );
+        }
+        Ok(())
+    }
 }
 
 impl<T: ReceiptResponse> ReceiptExt for T {}

--- a/e2e-tests-rust/src/test_contracts/mod.rs
+++ b/e2e-tests-rust/src/test_contracts/mod.rs
@@ -64,4 +64,13 @@ impl<N: Network, P: Provider<N>> Counter<N, P> {
     ) -> SolCallBuilder<(), &P, private::Counter::incrementCall, N> {
         self.0.increment(x.try_into().unwrap())
     }
+
+    pub fn increment_with_revert(
+        &self,
+        x: impl TryInto<U256, Error = impl Debug>,
+        should_revert: bool,
+    ) -> SolCallBuilder<(), &P, private::Counter::incrementWithRevertCall, N> {
+        self.0
+            .incrementWithRevert(x.try_into().unwrap(), should_revert)
+    }
 }

--- a/e2e-tests-rust/tests/revert.rs
+++ b/e2e-tests-rust/tests/revert.rs
@@ -1,0 +1,27 @@
+use alloy::primitives::U256;
+use anvil_zksync_e2e_tests::test_contracts::Counter;
+use anvil_zksync_e2e_tests::{AnvilZksyncTesterBuilder, ReceiptExt};
+
+#[tokio::test]
+async fn revert_during_estimation() -> anyhow::Result<()> {
+    let tester = AnvilZksyncTesterBuilder::default().build().await?;
+
+    // Deploy `Counter` contract and validate that it is initialized with `0`
+    let counter = Counter::deploy(tester.l2_provider()).await?;
+    assert_eq!(counter.get().await?, U256::from(0));
+
+    // Increment counter by 1
+    let estimate_gas_result = counter.increment_with_revert(1, true).estimate_gas().await;
+    let Err(err) = estimate_gas_result else {
+        anyhow::bail!("gas estimation should fail for reverting transactions")
+    };
+    println!("err: {:?}", err);
+    assert!(err
+        .to_string()
+        .contains(&hex::encode("This method always reverts")));
+
+    // Validate that the counter stayed the same
+    assert_eq!(counter.get().await?, U256::from(0));
+
+    Ok(())
+}

--- a/etc/errors/anvil.json
+++ b/etc/errors/anvil.json
@@ -1082,6 +1082,10 @@
                 {
                   "name": "inner",
                   "type": "Revert"
+                },
+                {
+                  "name": "data",
+                  "type": "bytes"
                 }
               ],
               "doc": {
@@ -1156,6 +1160,10 @@
                 {
                   "name": "inner",
                   "type": "Revert"
+                },
+                {
+                  "name": "data",
+                  "type": "bytes"
                 }
               ],
               "doc": {


### PR DESCRIPTION
# What :computer: 
*  The revert reasons are communicated in `data` field of the JSON RPC error object
* Reported in https://github.com/zkSync-Community-Hub/zksync-developers/discussions/1042 
# Why :hand:
* This is used by [hardhat-chai-matchers](https://github.com/NomicFoundation/hardhat/blob/main/packages/hardhat-chai-matchers/src/internal/reverted/utils.ts#L63)

# Evidence :camera:
Tests failing in https://github.com/safe-global/safe-smart-account caught the breaking change.

Bug: 
<img width="1785" alt="image" src="https://github.com/user-attachments/assets/ef7228fc-d16f-4f9d-9c5e-2438886f5915" />
  
After this fix:
<img width="1882" alt="image" src="https://github.com/user-attachments/assets/ce64da1c-3fb1-41ab-8f27-46ee48f471e0" />
