### PR TITLE
fix: remove stable usage for binary build due to zksyncos

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,6 @@ jobs:
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
           target: ${{ matrix.arch }}
 
       - name: Build anvil-zksync for ${{ matrix.arch }}


### PR DESCRIPTION
# What :computer: 
* use nightly for binary build

# Why :hand:
* zksyncos uses it

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
