### PR TITLE
fix: `zks_gasPerPubdata` to report derived value

### DIFF
--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -287,7 +287,7 @@ impl TestNodeConfig {
         // Banner, version and repository section.
         sh_println!(
             r#"
-{} 
+{}
 Version:        {}
 Repository:     {}
 
@@ -433,7 +433,7 @@ Node Configuration
 Port:                  {}
 EVM Interpreter:       {}
 Health Check Endpoint: {}
-ZKsync OS:              {}
+ZKsync OS:             {}
 L1:                    {}
 "#,
             self.port,

--- a/crates/core/src/node/fee_model.rs
+++ b/crates/core/src/node/fee_model.rs
@@ -138,12 +138,16 @@ impl TestNodeFeeInputProvider {
         self.enforce_base_fee(fee_input)
     }
 
-    pub fn gas_price(&self) -> u64 {
-        let (base_fee, _) = derive_base_fee_and_gas_per_pubdata(
+    pub fn gas_price_and_gas_per_pubdata(&self) -> (u64, u64) {
+        let (base_fee, gas_per_pubdata) = derive_base_fee_and_gas_per_pubdata(
             self.get_batch_fee_input_scaled(),
             VmVersion::latest(),
         );
-        base_fee
+        (base_fee, gas_per_pubdata)
+    }
+
+    pub fn fair_l2_gas_price(&self) -> u64 {
+        self.get_batch_fee_input_scaled().fair_l2_gas_price()
     }
 
     pub fn fair_pubdata_price(&self) -> u64 {


### PR DESCRIPTION
# What :computer: 

Fixes https://github.com/matter-labs/hardhat-zksync/issues/1812

Also fixed effective gas price reported in transaction receipts since we were using the value from provider instead of a combination of tx's fee and block base.

# Why :hand:

Reported gas per pubdata was incorrect