### PR TITLE
feat: feature gate zksync os

### DIFF
--- a/.github/workflows/build-stable.yaml
+++ b/.github/workflows/build-stable.yaml
@@ -1,0 +1,23 @@
+# Ensure that we can disable ZKsync OS and build on stable without it.
+name: build-stable
+
+on:
+  push:
+    branches: [main]
+    tags:
+      - 'v*'
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build-stable:
+    name: build-stable
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - name: Build on stable without features
+        run: cargo +stable build --all --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,10 +125,10 @@ backon = "1.3.0"
 # Local dependencies    #
 #########################
 anvil_zksync_api_decl = { path = "crates/api_decl" }
-anvil_zksync_api_server = { path = "crates/api_server" }
+anvil_zksync_api_server = { path = "crates/api_server", default-features = false }
 anvil_zksync_config = { path = "crates/config" }
 anvil_zksync_core = { path = "crates/core", default-features = false }
-anvil_zksync_l1_sidecar = { path = "crates/l1_sidecar" }
+anvil_zksync_l1_sidecar = { path = "crates/l1_sidecar", default-features = false }
 anvil_zksync_types = { path = "crates/types" }
 anvil_zksync_common = { path = "crates/common" }
 zksync_error = { path = "crates/zksync_error", default-features = true, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ strip = "debuginfo" # Automatically strip symbols from the binary.
 lto = "thin"        # Enable link-time optimization.
 
 [workspace.package]
-version = "0.6.9" # x-release-please-version
+version = "0.6.9"                                          # x-release-please-version
 edition = "2024"
 authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
 homepage = "https://zksync.io/"
@@ -127,7 +127,7 @@ backon = "1.3.0"
 anvil_zksync_api_decl = { path = "crates/api_decl" }
 anvil_zksync_api_server = { path = "crates/api_server" }
 anvil_zksync_config = { path = "crates/config" }
-anvil_zksync_core = { path = "crates/core" }
+anvil_zksync_core = { path = "crates/core", default-features = false }
 anvil_zksync_l1_sidecar = { path = "crates/l1_sidecar" }
 anvil_zksync_types = { path = "crates/types" }
 anvil_zksync_common = { path = "crates/common" }

--- a/crates/api_server/Cargo.toml
+++ b/crates/api_server/Cargo.toml
@@ -11,10 +11,10 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-anvil_zksync_api_decl.workspace = true
-anvil_zksync_core.workspace = true
-anvil_zksync_l1_sidecar.workspace = true
+anvil_zksync_l1_sidecar = { workspace = true, default-features = false }
+anvil_zksync_core = { workspace = true, default-features = false }
 anvil_zksync_types.workspace = true
+anvil_zksync_api_decl.workspace = true
 anvil_zksync_common.workspace = true
 
 zksync_types.workspace = true
@@ -34,3 +34,7 @@ tower.workspace = true
 tower-http.workspace = true
 tracing.workspace = true
 serde_json.workspace = true
+
+[features]
+default = ["zksync-os"]
+zksync-os = ["anvil_zksync_core/zksync-os", "anvil_zksync_l1_sidecar/zksync-os"]

--- a/crates/api_server/src/impls/anvil_zks.rs
+++ b/crates/api_server/src/impls/anvil_zks.rs
@@ -1,5 +1,5 @@
 use anvil_zksync_api_decl::AnvilZksNamespaceServer;
-use anvil_zksync_core::node::zksync_os_get_batch_witness;
+use anvil_zksync_core::node::ZkSyncOSHelpers;
 use anvil_zksync_l1_sidecar::L1Sidecar;
 use jsonrpsee::core::{RpcResult, async_trait};
 use zksync_types::web3::Bytes;
@@ -41,7 +41,7 @@ impl AnvilZksNamespaceServer for AnvilZksNamespace {
     }
 
     async fn get_witness(&self, batch_number: L1BatchNumber) -> RpcResult<Bytes> {
-        Ok(zksync_os_get_batch_witness(&batch_number)
+        Ok(ZkSyncOSHelpers::get_batch_witness(&batch_number)
             .ok_or(rpc_invalid_params(
                 "Batch with this number doesn't exist yet".to_string(),
             ))?

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -11,10 +11,10 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-anvil_zksync_api_server.workspace = true
 anvil_zksync_config.workspace = true
+anvil_zksync_api_server = { workspace = true, default-features = false }
 anvil_zksync_core = { workspace = true, default-features = false }
-anvil_zksync_l1_sidecar.workspace = true
+anvil_zksync_l1_sidecar = { workspace = true, default-features = false }
 anvil_zksync_types.workspace = true
 zksync_error.workspace = true
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -13,7 +13,7 @@ categories.workspace = true
 [dependencies]
 anvil_zksync_api_server.workspace = true
 anvil_zksync_config.workspace = true
-anvil_zksync_core.workspace = true
+anvil_zksync_core = { workspace = true, default-features = false }
 anvil_zksync_l1_sidecar.workspace = true
 anvil_zksync_types.workspace = true
 zksync_error.workspace = true
@@ -49,3 +49,7 @@ num.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+
+[features]
+default = ["zksync-os"]
+zksync-os = ["anvil_zksync_core/zksync-os"]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -26,12 +26,12 @@ zksync_error.workspace = true
 zksync-error-description.workspace = true
 
 # ZKsync OS dependencies
-forward_system.workspace = true
-basic_system.workspace = true
-zk_ee.workspace = true
-system_hooks.workspace = true
-zksync_os_api.workspace = true
-crypto.workspace = true
+forward_system = { workspace = true, optional = true }
+basic_system = { workspace = true, optional = true }
+zk_ee = { workspace = true, optional = true }
+system_hooks = { workspace = true, optional = true }
+zksync_os_api = { workspace = true, optional = true }
+crypto = { workspace = true, optional = true }
 
 anyhow.workspace = true
 tokio.workspace = true
@@ -71,3 +71,14 @@ httptest.workspace = true
 tempfile.workspace = true
 test-case.workspace = true
 backon.workspace = true
+
+[features]
+default = ["zksync-os"]
+zksync-os = [
+    "dep:forward_system",
+    "dep:basic_system",
+    "dep:zk_ee",
+    "dep:system_hooks",
+    "dep:zksync_os_api",
+    "dep:crypto",
+]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,6 +1,6 @@
-#![feature(allocator_api)]
-#![allow(incomplete_features)]
-#![feature(generic_const_exprs)]
+#![cfg_attr(feature = "zksync-os", feature(allocator_api))]
+#![cfg_attr(feature = "zksync-os", allow(incomplete_features))]
+#![cfg_attr(feature = "zksync-os", feature(generic_const_exprs))]
 //! anvil-zksync
 //!
 //! The `anvil-zksync` crate provides an in-memory node designed primarily for local testing.

--- a/crates/core/src/node/debug.rs
+++ b/crates/core/src/node/debug.rs
@@ -13,7 +13,7 @@ use zksync_types::web3::Bytes;
 use zksync_types::{H256, PackedEthSignature, Transaction, api};
 use zksync_web3_decl::error::Web3Error;
 
-use super::zksync_os::ZKSYNC_OS_CALL_GAS_LIMIT;
+use super::zksync_os::ZkSyncOSHelpers;
 
 impl InMemoryNode {
     pub async fn trace_block_impl(
@@ -86,7 +86,7 @@ impl InMemoryNode {
         // Protection against infinite-loop eth_calls and alike:
         // limiting the amount of gas the call can use.
         if self.system_contracts.zksync_os.zksync_os {
-            l2_tx.common_data.fee.gas_limit = ZKSYNC_OS_CALL_GAS_LIMIT.into();
+            l2_tx.common_data.fee.gas_limit = ZkSyncOSHelpers::call_gas_limit().into();
         } else {
             l2_tx.common_data.fee.gas_limit = ETH_CALL_GAS_LIMIT.into();
         }

--- a/crates/core/src/node/eth.rs
+++ b/crates/core/src/node/eth.rs
@@ -32,7 +32,7 @@ use crate::{
     utils::TransparentError,
 };
 
-use super::zksync_os::ZKSYNC_OS_CALL_GAS_LIMIT;
+use super::zksync_os::ZkSyncOSHelpers;
 
 impl InMemoryNode {
     pub async fn call_impl(
@@ -58,7 +58,7 @@ impl InMemoryNode {
         }
 
         if self.system_contracts.zksync_os.zksync_os {
-            tx.common_data.fee.gas_limit = ZKSYNC_OS_CALL_GAS_LIMIT.into();
+            tx.common_data.fee.gas_limit = ZkSyncOSHelpers::call_gas_limit().into();
         } else {
             tx.common_data.fee.gas_limit = ETH_CALL_GAS_LIMIT.into();
         }

--- a/crates/core/src/node/keys.rs
+++ b/crates/core/src/node/keys.rs
@@ -10,7 +10,9 @@ impl StorageKeyLayout {
     pub fn get_nonce_key(&self, account: &Address) -> StorageKey {
         match self {
             StorageKeyLayout::Era => zksync_types::get_nonce_key(account),
-            StorageKeyLayout::ZKsyncOs => crate::node::zksync_os::zksync_os_get_nonce_key(account),
+            StorageKeyLayout::ZKsyncOs => {
+                crate::node::zksync_os::ZkSyncOSHelpers::get_nonce_key(account)
+            }
         }
     }
 
@@ -18,7 +20,7 @@ impl StorageKeyLayout {
         match self {
             StorageKeyLayout::Era => zksync_types::utils::storage_key_for_eth_balance(address),
             StorageKeyLayout::ZKsyncOs => {
-                crate::node::zksync_os::zksync_os_storage_key_for_eth_balance(address)
+                crate::node::zksync_os::ZkSyncOSHelpers::storage_key_for_eth_balance(address)
             }
         }
     }

--- a/crates/core/src/node/mod.rs
+++ b/crates/core/src/node/mod.rs
@@ -29,4 +29,4 @@ pub use self::{
 pub use in_memory::*;
 pub use inner::InMemoryNodeInner;
 pub use inner::{blockchain, fork, node_executor, time};
-pub use zksync_os::zksync_os_get_batch_witness;
+pub use zksync_os::ZkSyncOSHelpers;

--- a/crates/core/src/node/zksync_os/mock/mod.rs
+++ b/crates/core/src/node/zksync_os/mock/mod.rs
@@ -1,0 +1,143 @@
+//! Interfaces that use zksync_os for VM execution.
+//! This is still experimental code.
+
+use anvil_zksync_config::types::ZKsyncOsConfig;
+use zksync_multivm::{
+    HistoryMode,
+    interface::{
+        L1BatchEnv, PushTransactionResult, SystemEnv, VmExecutionResultAndLogs, VmInterface,
+        VmInterfaceHistoryEnabled,
+        storage::{StoragePtr, WriteStorage},
+    },
+    tracers::TracerDispatcher,
+    vm_latest::TracerPointer,
+};
+
+use zksync_multivm::MultiVmTracerPointer;
+use zksync_types::{StorageKey, Transaction};
+
+use crate::deps::InMemoryStorage;
+
+#[derive(Debug)]
+pub struct MockZKsyncOsVM<S: WriteStorage, H: HistoryMode> {
+    _s: std::marker::PhantomData<S>,
+    _h: std::marker::PhantomData<H>,
+}
+
+impl<S: WriteStorage, H: HistoryMode> MockZKsyncOsVM<S, H> {
+    pub fn new(
+        _batch_env: L1BatchEnv,
+        _system_env: SystemEnv,
+        _storage: StoragePtr<S>,
+        _raw_storage: &InMemoryStorage,
+        _config: &ZKsyncOsConfig,
+    ) -> Self {
+        panic!(
+            "Cannot instantiate mock ZKsyncOsVM, make sure 'zksync-os' feature is enabled in Cargo.toml"
+        );
+    }
+
+    /// If any keys are updated in storage externally, but not reflected in internal tree.
+    pub fn update_inconsistent_keys(&mut self, _inconsistent_nodes: &[&StorageKey]) {
+        unimplemented!();
+    }
+}
+
+pub struct ZkSyncOSTracerDispatcher<S: WriteStorage, H: HistoryMode> {
+    _tracers: Vec<S>,
+    _marker: std::marker::PhantomData<H>,
+}
+
+impl<S: WriteStorage, H: HistoryMode> Default for ZkSyncOSTracerDispatcher<S, H> {
+    fn default() -> Self {
+        Self {
+            _tracers: Default::default(),
+            _marker: Default::default(),
+        }
+    }
+}
+
+impl<S: WriteStorage, H: HistoryMode> From<Vec<TracerPointer<S, H>>>
+    for ZkSyncOSTracerDispatcher<S, H>
+{
+    fn from(_value: Vec<TracerPointer<S, H>>) -> Self {
+        Self {
+            _tracers: Default::default(),
+            _marker: Default::default(),
+        }
+    }
+}
+
+impl<S: WriteStorage, H: HistoryMode> From<Vec<MultiVmTracerPointer<S, H>>>
+    for ZkSyncOSTracerDispatcher<S, H>
+{
+    fn from(_value: Vec<MultiVmTracerPointer<S, H>>) -> Self {
+        Self {
+            _tracers: Default::default(),
+            _marker: Default::default(),
+        }
+    }
+}
+
+impl<S: WriteStorage, H: HistoryMode> From<TracerDispatcher<S, H>>
+    for ZkSyncOSTracerDispatcher<S, H>
+{
+    fn from(_value: TracerDispatcher<S, H>) -> Self {
+        Self {
+            _tracers: Default::default(),
+            _marker: Default::default(),
+        }
+    }
+}
+
+impl<S: WriteStorage, H: HistoryMode> VmInterface for MockZKsyncOsVM<S, H> {
+    type TracerDispatcher = ZkSyncOSTracerDispatcher<S, H>;
+
+    fn push_transaction(
+        &mut self,
+        _tx: Transaction,
+    ) -> zksync_multivm::interface::PushTransactionResult<'_> {
+        unimplemented!()
+    }
+
+    fn inspect(
+        &mut self,
+        _dispatcher: &mut Self::TracerDispatcher,
+        _execution_mode: zksync_multivm::interface::InspectExecutionMode,
+    ) -> VmExecutionResultAndLogs {
+        unimplemented!()
+    }
+
+    fn start_new_l2_block(&mut self, _l2_block_env: zksync_multivm::interface::L2BlockEnv) {
+        // no-op
+    }
+
+    fn inspect_transaction_with_bytecode_compression(
+        &mut self,
+        _tracer: &mut Self::TracerDispatcher,
+        _tx: Transaction,
+        _with_compression: bool,
+    ) -> (
+        zksync_multivm::interface::BytecodeCompressionResult<'_>,
+        VmExecutionResultAndLogs,
+    ) {
+        todo!()
+    }
+
+    fn finish_batch(
+        &mut self,
+        _pubdata_builder: std::rc::Rc<dyn zksync_multivm::interface::pubdata::PubdataBuilder>,
+    ) -> zksync_multivm::interface::FinishedL1Batch {
+        todo!()
+    }
+}
+
+impl<S: WriteStorage, H: HistoryMode> VmInterfaceHistoryEnabled for MockZKsyncOsVM<S, H> {
+    fn make_snapshot(&mut self) {}
+
+    fn rollback_to_the_latest_snapshot(&mut self) {
+        panic!("Not implemented for zksync_os");
+    }
+
+    fn pop_snapshot_no_rollback(&mut self) {}
+}

--- a/crates/core/src/node/zksync_os/mock/mod.rs
+++ b/crates/core/src/node/zksync_os/mock/mod.rs
@@ -5,8 +5,7 @@ use anvil_zksync_config::types::ZKsyncOsConfig;
 use zksync_multivm::{
     HistoryMode,
     interface::{
-        L1BatchEnv, PushTransactionResult, SystemEnv, VmExecutionResultAndLogs, VmInterface,
-        VmInterfaceHistoryEnabled,
+        L1BatchEnv, SystemEnv, VmExecutionResultAndLogs, VmInterface, VmInterfaceHistoryEnabled,
         storage::{StoragePtr, WriteStorage},
     },
     tracers::TracerDispatcher,

--- a/crates/core/src/node/zksync_os/mod.rs
+++ b/crates/core/src/node/zksync_os/mod.rs
@@ -1,0 +1,61 @@
+#[cfg(not(feature = "zksync-os"))]
+mod mock;
+#[cfg(feature = "zksync-os")]
+mod real;
+
+use zksync_types::{Address, StorageKey};
+
+#[cfg(not(feature = "zksync-os"))]
+pub use self::mock::MockZKsyncOsVM;
+
+#[cfg(feature = "zksync-os")]
+pub use self::real::ZKsyncOsVM;
+
+pub struct ZkSyncOSHelpers;
+
+impl ZkSyncOSHelpers {
+    pub const fn call_gas_limit() -> u64 {
+        #[cfg(feature = "zksync-os")]
+        {
+            self::real::ZKSYNC_OS_CALL_GAS_LIMIT
+        }
+
+        #[cfg(not(feature = "zksync-os"))]
+        {
+            panic!("Cannot use ZkSyncOSHelpers without 'zksync-os' feature enabled");
+        }
+    }
+
+    pub fn get_nonce_key(account: &Address) -> StorageKey {
+        #[cfg(feature = "zksync-os")]
+        {
+            self::real::zksync_os_get_nonce_key(account)
+        }
+        #[cfg(not(feature = "zksync-os"))]
+        {
+            panic!("Cannot use ZkSyncOSHelpers without 'zksync-os' feature enabled");
+        }
+    }
+
+    pub fn get_batch_witness(key: &u32) -> Option<Vec<u8>> {
+        #[cfg(feature = "zksync-os")]
+        {
+            self::real::zksync_os_get_batch_witness(key)
+        }
+        #[cfg(not(feature = "zksync-os"))]
+        {
+            panic!("Cannot use ZkSyncOSHelpers without 'zksync-os' feature enabled");
+        }
+    }
+
+    pub fn storage_key_for_eth_balance(address: &Address) -> StorageKey {
+        #[cfg(feature = "zksync-os")]
+        {
+            self::real::zksync_os_storage_key_for_eth_balance(address)
+        }
+        #[cfg(not(feature = "zksync-os"))]
+        {
+            panic!("Cannot use ZkSyncOSHelpers without 'zksync-os' feature enabled");
+        }
+    }
+}

--- a/crates/core/src/node/zksync_os/mod.rs
+++ b/crates/core/src/node/zksync_os/mod.rs
@@ -1,12 +1,19 @@
+#![cfg_attr(not(feature = "zksync-os"), allow(unused_variables))]
+
 #[cfg(not(feature = "zksync-os"))]
 mod mock;
+
+// NEVER expose anything from this module directly.
+// Use `ZkSyncOsHelpers` instead and make sure to mimic functionality for the mock impl.
+// ZKsync OS requires nightly, but foundry-zksync uses anvil-zksync as a dependency and is built with stable.
+// Exposing ZKsync OS without a feature flag will cause build errors in foundry-zksync.
 #[cfg(feature = "zksync-os")]
 mod real;
 
 use zksync_types::{Address, StorageKey};
 
 #[cfg(not(feature = "zksync-os"))]
-pub use self::mock::MockZKsyncOsVM;
+pub use self::mock::MockZKsyncOsVM as ZKsyncOsVM;
 
 #[cfg(feature = "zksync-os")]
 pub use self::real::ZKsyncOsVM;

--- a/crates/core/src/node/zksync_os/real/mod.rs
+++ b/crates/core/src/node/zksync_os/real/mod.rs
@@ -1,0 +1,222 @@
+//! Interfaces that use zksync_os for VM execution.
+//! This is still experimental code.
+use std::vec;
+
+use anvil_zksync_config::types::ZKsyncOsConfig;
+use forward_system::run::test_impl::{InMemoryPreimageSource, InMemoryTree};
+use zksync_multivm::{
+    HistoryMode,
+    interface::{
+        ExecutionResult, InspectExecutionMode, L1BatchEnv, PushTransactionResult, SystemEnv,
+        TxExecutionMode, VmExecutionResultAndLogs, VmInterface, VmInterfaceHistoryEnabled,
+        storage::{StoragePtr, WriteStorage},
+    },
+    tracers::TracerDispatcher,
+    vm_latest::TracerPointer,
+};
+
+use zksync_multivm::MultiVmTracerPointer;
+use zksync_types::{StorageKey, Transaction};
+
+use crate::deps::InMemoryStorage;
+
+mod helpers;
+
+// Only put things that _have_ to be public here.
+pub use self::helpers::{
+    ZKSYNC_OS_CALL_GAS_LIMIT, zksync_os_get_batch_witness, zksync_os_get_nonce_key,
+    zksync_os_storage_key_for_eth_balance,
+};
+
+use self::helpers::*;
+
+#[derive(Debug)]
+pub struct ZKsyncOsVM<S: WriteStorage, H: HistoryMode> {
+    pub storage: StoragePtr<S>,
+    pub tree: InMemoryTree,
+    preimage: InMemoryPreimageSource,
+    transactions: Vec<Transaction>,
+    system_env: SystemEnv,
+    batch_env: L1BatchEnv,
+    config: ZKsyncOsConfig,
+    witness: Option<Vec<u8>>,
+    _phantom: std::marker::PhantomData<H>,
+}
+
+impl<S: WriteStorage, H: HistoryMode> ZKsyncOsVM<S, H> {
+    pub fn new(
+        batch_env: L1BatchEnv,
+        system_env: SystemEnv,
+        storage: StoragePtr<S>,
+        raw_storage: &InMemoryStorage,
+        config: &ZKsyncOsConfig,
+    ) -> Self {
+        let (tree, preimage) = { create_tree_from_full_state(raw_storage) };
+        ZKsyncOsVM {
+            storage,
+            tree,
+            preimage,
+            transactions: vec![],
+            system_env,
+            batch_env,
+            witness: None,
+            config: config.clone(),
+            _phantom: Default::default(),
+        }
+    }
+
+    /// If any keys are updated in storage externally, but not reflected in internal tree.
+    pub fn update_inconsistent_keys(&mut self, inconsistent_nodes: &[&StorageKey]) {
+        for key in inconsistent_nodes {
+            let value = self.storage.borrow_mut().read_value(key);
+            add_elem_to_tree(&mut self.tree, key, &value);
+        }
+    }
+}
+
+pub struct ZkSyncOSTracerDispatcher<S: WriteStorage, H: HistoryMode> {
+    _tracers: Vec<S>,
+    _marker: std::marker::PhantomData<H>,
+}
+
+impl<S: WriteStorage, H: HistoryMode> Default for ZkSyncOSTracerDispatcher<S, H> {
+    fn default() -> Self {
+        Self {
+            _tracers: Default::default(),
+            _marker: Default::default(),
+        }
+    }
+}
+
+impl<S: WriteStorage, H: HistoryMode> From<Vec<TracerPointer<S, H>>>
+    for ZkSyncOSTracerDispatcher<S, H>
+{
+    fn from(_value: Vec<TracerPointer<S, H>>) -> Self {
+        Self {
+            _tracers: Default::default(),
+            _marker: Default::default(),
+        }
+    }
+}
+
+impl<S: WriteStorage, H: HistoryMode> From<Vec<MultiVmTracerPointer<S, H>>>
+    for ZkSyncOSTracerDispatcher<S, H>
+{
+    fn from(_value: Vec<MultiVmTracerPointer<S, H>>) -> Self {
+        Self {
+            _tracers: Default::default(),
+            _marker: Default::default(),
+        }
+    }
+}
+
+impl<S: WriteStorage, H: HistoryMode> From<TracerDispatcher<S, H>>
+    for ZkSyncOSTracerDispatcher<S, H>
+{
+    fn from(_value: TracerDispatcher<S, H>) -> Self {
+        Self {
+            _tracers: Default::default(),
+            _marker: Default::default(),
+        }
+    }
+}
+
+impl<S: WriteStorage, H: HistoryMode> VmInterface for ZKsyncOsVM<S, H> {
+    type TracerDispatcher = ZkSyncOSTracerDispatcher<S, H>;
+
+    fn push_transaction(
+        &mut self,
+        tx: Transaction,
+    ) -> zksync_multivm::interface::PushTransactionResult<'_> {
+        self.transactions.push(tx);
+        PushTransactionResult {
+            compressed_bytecodes: Default::default(),
+        }
+    }
+
+    fn inspect(
+        &mut self,
+        _dispatcher: &mut Self::TracerDispatcher,
+        execution_mode: zksync_multivm::interface::InspectExecutionMode,
+    ) -> VmExecutionResultAndLogs {
+        if let InspectExecutionMode::Bootloader = execution_mode {
+            // This is called at the end of seal block.
+            // Now is the moment to collect the witness and store it.
+
+            // TODO: add support for multiple transactions.
+
+            if let Some(witness) = self.witness.clone() {
+                set_batch_witness(self.batch_env.number.0, witness);
+            }
+
+            return VmExecutionResultAndLogs {
+                result: ExecutionResult::Success { output: vec![] },
+                logs: Default::default(),
+                statistics: Default::default(),
+                refunds: Default::default(),
+                dynamic_factory_deps: Default::default(),
+            };
+        }
+        let simulate_only = match self.system_env.execution_mode {
+            TxExecutionMode::VerifyExecute => false,
+            TxExecutionMode::EstimateFee => true,
+            TxExecutionMode::EthCall => true,
+        };
+
+        // For now we only support one transaction.
+        assert_eq!(
+            1,
+            self.transactions.len(),
+            "only one tx per batch supported for now"
+        );
+
+        // TODO: add support for multiple transactions.
+        let tx = self.transactions[0].clone();
+        let (result, witness) = execute_tx_in_zkos(
+            &tx,
+            &self.tree,
+            &self.preimage,
+            &mut self.storage,
+            simulate_only,
+            &self.batch_env,
+            self.system_env.chain_id.as_u64(),
+            self.config.zksync_os_bin_path.clone(),
+        );
+
+        self.witness = witness;
+        result
+    }
+
+    fn start_new_l2_block(&mut self, _l2_block_env: zksync_multivm::interface::L2BlockEnv) {
+        // no-op
+    }
+
+    fn inspect_transaction_with_bytecode_compression(
+        &mut self,
+        _tracer: &mut Self::TracerDispatcher,
+        _tx: Transaction,
+        _with_compression: bool,
+    ) -> (
+        zksync_multivm::interface::BytecodeCompressionResult<'_>,
+        VmExecutionResultAndLogs,
+    ) {
+        todo!()
+    }
+
+    fn finish_batch(
+        &mut self,
+        _pubdata_builder: std::rc::Rc<dyn zksync_multivm::interface::pubdata::PubdataBuilder>,
+    ) -> zksync_multivm::interface::FinishedL1Batch {
+        todo!()
+    }
+}
+
+impl<S: WriteStorage, H: HistoryMode> VmInterfaceHistoryEnabled for ZKsyncOsVM<S, H> {
+    fn make_snapshot(&mut self) {}
+
+    fn rollback_to_the_latest_snapshot(&mut self) {
+        panic!("Not implemented for zksync_os");
+    }
+
+    fn pop_snapshot_no_rollback(&mut self) {}
+}

--- a/crates/l1_sidecar/Cargo.toml
+++ b/crates/l1_sidecar/Cargo.toml
@@ -11,15 +11,21 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-anvil_zksync_common.workspace = true
-anvil_zksync_core.workspace = true
+anvil_zksync_core = { workspace = true, default-features = false }
 anvil_zksync_types.workspace = true
+anvil_zksync_common.workspace = true
 
 zksync_contracts.workspace = true
 zksync_mini_merkle_tree.workspace = true
 zksync_types.workspace = true
 
-alloy = { workspace = true, default-features = false, features = ["sol-types", "rpc-types", "providers", "kzg", "provider-anvil-api"] }
+alloy = { workspace = true, default-features = false, features = [
+    "sol-types",
+    "rpc-types",
+    "providers",
+    "kzg",
+    "provider-anvil-api",
+] }
 anyhow.workspace = true
 hex.workspace = true
 tempfile.workspace = true
@@ -34,3 +40,7 @@ tracing.workspace = true
 
 [dev-dependencies]
 async-trait.workspace = true
+
+[features]
+default = ["zksync-os"]
+zksync-os = ["anvil_zksync_core/zksync-os"]


### PR DESCRIPTION
Puts zksync os behind a feature, but makes it enabled by default.
This is needed to keep foundry-zksync on stable, as it doesn't care about zksync os.
Also adds a CI check to make sure we don't loose ability to build code on stable.