### PR TITLE
fix: workaround to fix deploy docs ci issue

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -67,7 +67,7 @@ jobs:
           cargo doc --no-deps
           cp -r target/doc docs/book/src/rustdoc
 
-      - name: Neutralize local changes caused by build
+      - name: Restore zksync_error crate if needed
         if: ${{ github.event_name != 'pull_request' }}
         run: |
           git restore --worktree --staged crates/zksync_error/src || true

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -67,6 +67,11 @@ jobs:
           cargo doc --no-deps
           cp -r target/doc docs/book/src/rustdoc
 
+      - name: Neutralize local changes caused by build
+        if: ${{ github.event_name != 'pull_request' }}
+        run: |
+          git restore --worktree --staged crates/zksync_error/src || true
+
       - name: Deploy core docs
         uses: matter-labs/deploy-mdbooks@c72ae3825faeb7d20cbf3e67714f7253dd0ee7cb # v1
         with:


### PR DESCRIPTION
# What :computer: 
* Restore zksync-error crate formatting changes during docs deployment

# Why :hand:
* Currently breaks the deploy docs ci flow

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
