### PR TITLE
fix: adjust timeout for autoexecute

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1988,7 +1988,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
 dependencies = [
  "memchr",
- "regex-automata 0.4.9",
+ "regex-automata",
  "serde",
 ]
 
@@ -3630,8 +3630,8 @@ dependencies = [
  "aho-corasick",
  "bstr",
  "log",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -4210,7 +4210,7 @@ dependencies = [
  "globset",
  "log",
  "memchr",
- "regex-automata 0.4.9",
+ "regex-automata",
  "same-file",
  "walkdir",
  "winapi-util",
@@ -4848,11 +4848,11 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.1.10",
+ "regex-automata",
 ]
 
 [[package]]
@@ -4962,12 +4962,11 @@ source = "git+https://github.com/matter-labs/zksync-airbender?tag=v0.3.1#44a1721
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
 dependencies = [
- "overload",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5226,12 +5225,6 @@ name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p256"
@@ -5715,7 +5708,7 @@ dependencies = [
  "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rand_xorshift",
- "regex-syntax 0.8.5",
+ "regex-syntax",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -6085,17 +6078,8 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -6106,7 +6090,7 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -6114,12 +6098,6 @@ name = "regex-lite"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -8045,14 +8023,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex",
+ "regex-automata",
  "serde",
  "serde_json",
  "sharded-slab",

--- a/e2e-tests-rust/tests/l1.rs
+++ b/e2e-tests-rust/tests/l1.rs
@@ -469,7 +469,7 @@ async fn auto_execute_batch(protocol_version: u16) -> anyhow::Result<()> {
     let filter = Filter::new().event_signature(BlockExecution::SIGNATURE_HASH);
     let filter_id = tester.l1_provider().new_filter(&filter).await?;
 
-    const BATCHES: usize = 5;
+    const BATCHES: usize = 3;
 
     // Pre-generate a few batches for the rest of the test
     for _ in 0..BATCHES {

--- a/e2e-tests-rust/tests/l1.rs
+++ b/e2e-tests-rust/tests/l1.rs
@@ -457,7 +457,7 @@ async fn auto_execute_batch(protocol_version: u16) -> anyhow::Result<()> {
     let tester = AnvilZksyncTesterBuilder::default()
         .with_l1()
         .with_node_fn(&move |node| {
-            node.timeout(60_000).args([
+            node.timeout(100_000).args([
                 "--auto-execute-l1",
                 "--protocol-version",
                 &protocol_version.to_string(),

--- a/e2e-tests-rust/tests/l1.rs
+++ b/e2e-tests-rust/tests/l1.rs
@@ -469,14 +469,14 @@ async fn auto_execute_batch(protocol_version: u16) -> anyhow::Result<()> {
     let filter = Filter::new().event_signature(BlockExecution::SIGNATURE_HASH);
     let filter_id = tester.l1_provider().new_filter(&filter).await?;
 
-    const BATCHES: usize = 3;
+    const BATCHES: usize = 5;
 
     // Pre-generate a few batches for the rest of the test
     for _ in 0..BATCHES {
         tester.tx().finalize().await?.assert_successful()?;
     }
 
-    const ATTEMPTS: usize = 10;
+    const ATTEMPTS: usize = 30;
     let mut logs = Vec::with_capacity(BATCHES);
     for _ in 0..ATTEMPTS {
         let new_logs = tester
@@ -487,7 +487,7 @@ async fn auto_execute_batch(protocol_version: u16) -> anyhow::Result<()> {
         if logs.len() >= BATCHES {
             return Ok(());
         }
-        tokio::time::sleep(Duration::from_millis(500)).await;
+        tokio::time::sleep(Duration::from_millis(1)).await;
     }
     anyhow::bail!("failed to produce {BATCHES} batches in time, logs: {logs:?}")
 }

--- a/e2e-tests-rust/tests/l1.rs
+++ b/e2e-tests-rust/tests/l1.rs
@@ -487,7 +487,7 @@ async fn auto_execute_batch(protocol_version: u16) -> anyhow::Result<()> {
         if logs.len() >= BATCHES {
             return Ok(());
         }
-        tokio::time::sleep(Duration::from_millis(1)).await;
+        tokio::time::sleep(Duration::from_secs(1)).await;
     }
     anyhow::bail!("failed to produce {BATCHES} batches in time, logs: {logs:?}")
 }


### PR DESCRIPTION
# What :computer: 
* Bumps tracing-subscriber dep to latest 
* Bumps sleep timeout for auto execute e2e test

# Why :hand:
* Cargo deny flagged version as a concern
* Ubuntu was consistently failing due to not enough sleep time between test runs

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
