### PR TITLE
fix: honor --system-contracts-path when loading the local EVM emulator

### DIFF
--- a/crates/core/src/system_contracts.rs
+++ b/crates/core/src/system_contracts.rs
@@ -5,7 +5,7 @@ use crate::node::ImpersonationManager;
 use anvil_zksync_config::types::{SystemContractsOptions, ZKsyncOsConfig};
 use zksync_contracts::{
     BaseSystemContracts, BaseSystemContractsHashes, ContractLanguage, SystemContractCode,
-    SystemContractsRepo, read_sys_contract_bytecode,
+    SystemContractsRepo,
 };
 use zksync_multivm::interface::TxExecutionMode;
 use zksync_types::bytecode::BytecodeHash;
@@ -246,7 +246,7 @@ fn bsc_load_with_bootloader(
     let evm_emulator = if use_evm_emulator {
         let evm_emulator_bytecode = match options {
             SystemContractsOptions::Local => {
-                read_sys_contract_bytecode("", "EvmEmulator", ContractLanguage::Yul)
+                repo.read_sys_contract_bytecode("", "EvmEmulator", None, ContractLanguage::Yul)
             }
             SystemContractsOptions::BuiltIn | SystemContractsOptions::BuiltInWithoutSecurity => {
                 load_builtin_contract(protocol_version, "EvmEmulator")


### PR DESCRIPTION
`bsc_load_with_bootloader` loads the EVM emulator for `SystemContractsOptions::Local` through the free `read_sys_contract_bytecode`, which resolves against the default repo location, rather than the `repo` it builds from `system_contracts_path` twenty lines earlier. It is the only `Local` load in the file that does not go through `repo` — the default account and all five bootloaders do.

The effect is that `--dev-system-contracts=local --system-contracts-path=X` honors X for every contract except the emulator, which comes from `<cwd>/contracts/system-contracts/zkout/EvmEmulator.yul/EvmEmulator.json` instead. Depending on cwd that is either a panic or, worse, a silently different emulator than the one the flag asked for.

### How we hit it

In era-contracts we wanted `EvmEmulation.spec.ts` to exercise the emulator in the working tree rather than the built-in one, so emulator changes are covered by something. With `--system-contracts-path` pointed at our artifacts, every other contract loaded and only the emulator resolved elsewhere:

```
Can't find bytecode for 'EvmEmulator' yul contract at "./contracts/system-contracts/contracts-preprocessed/artifacts" or
["./contracts/system-contracts/zkout/EvmEmulator.yul/EvmEmulator.json", ...]
```

### Checks

`cargo fmt --check` and `cargo check -p anvil_zksync_core` are clean. `cargo clippy -p anvil_zksync_core --all-targets -- -D warnings` reports 3 `await_holding_lock` errors in `crates/core/src/node/inner/in_memory_inner.rs`; those reproduce unchanged on `main`, so they are pre-existing and untouched here.

Unrelated, but you may want to know: `crates/zksync_error`'s build script invokes `rustfmt` from `PATH`, which picks up the caller's default toolchain rather than the pinned `nightly-2025-03-19`. On a recent nightly its rustfmt ICEs on a generated `macro_rules!` and the build fails until you force the pinned toolchain onto `PATH`.

This does not by itself make local mode usable for a protocol version newer than the pinned core — that is a separate problem — but it removes a silent wrong-bytecode path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)