### PR TITLE
feat: add --evm-emulator-path to override the EVM emulator bytecode

### DIFF
--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -164,6 +164,15 @@ pub struct Cli {
     )]
     pub system_contracts_path: Option<PathBuf>,
 
+    /// Override the EVM emulator bytecode with a compiled artifact, independently of
+    /// --dev-system-contracts. Useful for testing a locally built emulator.
+    #[arg(
+        long,
+        help_heading = "System Configuration",
+        value_parser = clap::value_parser!(PathBuf),
+    )]
+    pub evm_emulator_path: Option<PathBuf>,
+
     #[arg(long, value_parser = protocol_version_from_str, help_heading = "System Configuration")]
     /// Protocol version to use for new blocks (default: 26). Also affects revision of built-in
     /// contracts that will get deployed (if applicable).
@@ -706,6 +715,7 @@ impl Cli {
             .with_silent(self.silent)
             .with_system_contracts(self.dev_system_contracts)
             .with_system_contracts_path(self.system_contracts_path.clone())
+            .with_evm_emulator_path(self.evm_emulator_path.clone())
             .with_protocol_version(self.protocol_version)
             .with_override_bytecodes_dir(self.override_bytecodes_dir.clone())
             .with_enforce_bytecode_compression(self.enforce_bytecode_compression)

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -315,6 +315,7 @@ async fn start_program(opt: Cli) -> Result<(), AnvilZksyncError> {
     let system_contracts = SystemContractsBuilder::new()
         .system_contracts_options(config.system_contracts_options)
         .system_contracts_path(config.system_contracts_path.clone())
+        .evm_emulator_path(config.evm_emulator_path.clone())
         .protocol_version(config.protocol_version())
         .with_evm_interpreter(config.use_evm_interpreter)
         .with_zksync_os(config.zksync_os.clone())

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -72,6 +72,9 @@ pub struct TestNodeConfig {
     pub system_contracts_options: SystemContractsOptions,
     /// Path to the system contracts directory
     pub system_contracts_path: Option<PathBuf>,
+    /// Path to a compiled EVM emulator artifact, overriding the one that the system contracts
+    /// choice would otherwise supply
+    pub evm_emulator_path: Option<PathBuf>,
     /// Protocol version to use for new blocks. Also affects revision of built-in contracts that
     /// will get deployed (if applicable)
     pub protocol_version: Option<ProtocolVersionId>,
@@ -205,6 +208,7 @@ impl Default for TestNodeConfig {
             silent: false,
             system_contracts_options: Default::default(),
             system_contracts_path: None,
+            evm_emulator_path: None,
             protocol_version: None,
             override_bytecodes_dir: None,
             bytecode_compression: false,
@@ -615,6 +619,15 @@ Address: {address}
     pub fn with_system_contracts_path(mut self, path: Option<PathBuf>) -> Self {
         if let Some(path) = path {
             self.system_contracts_path = Some(path);
+        }
+        self
+    }
+
+    /// Set the EVM emulator artifact path
+    #[must_use]
+    pub fn with_evm_emulator_path(mut self, path: Option<PathBuf>) -> Self {
+        if let Some(path) = path {
+            self.evm_emulator_path = Some(path);
         }
         self
     }

--- a/crates/core/src/node/in_memory.rs
+++ b/crates/core/src/node/in_memory.rs
@@ -629,6 +629,7 @@ impl InMemoryNode {
         let system_contracts = SystemContracts::from_options(
             config.system_contracts_options,
             config.system_contracts_path.clone(),
+            config.evm_emulator_path.clone(),
             ProtocolVersionId::latest(),
             config.use_evm_interpreter,
             config.zksync_os.clone(),

--- a/crates/core/src/node/inner/in_memory_inner.rs
+++ b/crates/core/src/node/inner/in_memory_inner.rs
@@ -1282,6 +1282,7 @@ pub mod testing {
             let system_contracts = SystemContracts::from_options(
                 config.system_contracts_options,
                 config.system_contracts_path.clone(),
+                config.evm_emulator_path.clone(),
                 ProtocolVersionId::latest(),
                 config.use_evm_interpreter,
                 config.zksync_os.clone(),

--- a/crates/core/src/node/inner/vm_runner.rs
+++ b/crates/core/src/node/inner/vm_runner.rs
@@ -703,6 +703,7 @@ mod test {
             let system_contracts = SystemContracts::from_options(
                 config.system_contracts_options,
                 config.system_contracts_path.clone(),
+                config.evm_emulator_path.clone(),
                 ProtocolVersionId::latest(),
                 config.use_evm_interpreter,
                 config.zksync_os.clone(),

--- a/crates/core/src/system_contracts.rs
+++ b/crates/core/src/system_contracts.rs
@@ -5,7 +5,7 @@ use crate::node::ImpersonationManager;
 use anvil_zksync_config::types::{SystemContractsOptions, ZKsyncOsConfig};
 use zksync_contracts::{
     BaseSystemContracts, BaseSystemContractsHashes, ContractLanguage, SystemContractCode,
-    SystemContractsRepo, read_sys_contract_bytecode,
+    SystemContractsRepo,
 };
 use zksync_multivm::interface::TxExecutionMode;
 use zksync_types::bytecode::BytecodeHash;
@@ -246,7 +246,7 @@ fn bsc_load_with_bootloader(
     let evm_emulator = if use_evm_emulator {
         let evm_emulator_bytecode = match options {
             SystemContractsOptions::Local => {
-                read_sys_contract_bytecode("", "EvmEmulator", ContractLanguage::Yul)
+                repo.read_sys_contract_bytecode("", "EvmEmulator", None, ContractLanguage::Yul)
             }
             SystemContractsOptions::BuiltIn | SystemContractsOptions::BuiltInWithoutSecurity => {
                 load_builtin_contract(protocol_version, "EvmEmulator")

--- a/crates/core/src/system_contracts.rs
+++ b/crates/core/src/system_contracts.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use crate::deps::system_contracts::load_builtin_contract;
+use crate::deps::system_contracts::{bytecode_from_slice, load_builtin_contract};
 use crate::node::ImpersonationManager;
 use anvil_zksync_config::types::{SystemContractsOptions, ZKsyncOsConfig};
 use zksync_contracts::{
@@ -16,6 +16,7 @@ use zksync_types::{Address, ProtocolVersionId};
 pub struct SystemContractsBuilder {
     system_contracts_options: Option<SystemContractsOptions>,
     system_contracts_path: Option<PathBuf>,
+    evm_emulator_path: Option<PathBuf>,
     protocol_version: Option<ProtocolVersionId>,
     use_evm_interpreter: bool,
     zksync_os: ZKsyncOsConfig,
@@ -36,6 +37,13 @@ impl SystemContractsBuilder {
     /// Set the system contracts path
     pub fn system_contracts_path(mut self, path: Option<PathBuf>) -> Self {
         self.system_contracts_path = path;
+        self
+    }
+
+    /// Override the EVM emulator bytecode with an explicit artifact, independently of the
+    /// system contracts choice.
+    pub fn evm_emulator_path(mut self, path: Option<PathBuf>) -> Self {
+        self.evm_emulator_path = path;
         self
     }
 
@@ -77,6 +85,7 @@ impl SystemContractsBuilder {
         SystemContracts::from_options(
             options,
             self.system_contracts_path,
+            self.evm_emulator_path,
             protocol_version,
             self.use_evm_interpreter,
             self.zksync_os,
@@ -111,6 +120,7 @@ impl SystemContracts {
     pub fn from_options(
         options: SystemContractsOptions,
         system_contracts_path: Option<PathBuf>,
+        evm_emulator_path: Option<PathBuf>,
         protocol_version: ProtocolVersionId,
         use_evm_emulator: bool,
         zksync_os: ZKsyncOsConfig,
@@ -122,6 +132,7 @@ impl SystemContracts {
             "initializing system contracts"
         );
         let path = system_contracts_path.unwrap_or_else(|| SystemContractsRepo::default().root);
+        let emulator_path = evm_emulator_path.as_deref();
         Self {
             protocol_version,
             baseline_contracts: baseline_contracts(
@@ -129,25 +140,35 @@ impl SystemContracts {
                 protocol_version,
                 use_evm_emulator,
                 &path,
+                emulator_path,
             ),
-            playground_contracts: playground(options, protocol_version, use_evm_emulator, &path),
+            playground_contracts: playground(
+                options,
+                protocol_version,
+                use_evm_emulator,
+                &path,
+                emulator_path,
+            ),
             fee_estimate_contracts: fee_estimate_contracts(
                 options,
                 protocol_version,
                 use_evm_emulator,
                 &path,
+                emulator_path,
             ),
             baseline_impersonating_contracts: baseline_impersonating_contracts(
                 options,
                 protocol_version,
                 use_evm_emulator,
                 &path,
+                emulator_path,
             ),
             fee_estimate_impersonating_contracts: fee_estimate_impersonating_contracts(
                 options,
                 protocol_version,
                 use_evm_emulator,
                 &path,
+                emulator_path,
             ),
             use_evm_emulator,
             zksync_os,
@@ -216,6 +237,7 @@ fn bsc_load_with_bootloader(
     protocol_version: ProtocolVersionId,
     use_evm_emulator: bool,
     system_contracts_path: &Path,
+    evm_emulator_path: Option<&Path>,
 ) -> BaseSystemContracts {
     let repo = system_contracts_repo(system_contracts_path);
     let hash = BytecodeHash::for_bytecode(&bootloader_bytecode);
@@ -244,11 +266,13 @@ fn bsc_load_with_bootloader(
     };
 
     let evm_emulator = if use_evm_emulator {
-        let evm_emulator_bytecode = match options {
-            SystemContractsOptions::Local => {
+        let evm_emulator_bytecode = match (evm_emulator_path, options) {
+            (Some(path), _) => read_evm_emulator_artifact(path),
+            (None, SystemContractsOptions::Local) => {
                 repo.read_sys_contract_bytecode("", "EvmEmulator", None, ContractLanguage::Yul)
             }
-            SystemContractsOptions::BuiltIn | SystemContractsOptions::BuiltInWithoutSecurity => {
+            (None, SystemContractsOptions::BuiltIn)
+            | (None, SystemContractsOptions::BuiltInWithoutSecurity) => {
                 load_builtin_contract(protocol_version, "EvmEmulator")
             }
         };
@@ -274,6 +298,7 @@ fn playground(
     protocol_version: ProtocolVersionId,
     use_evm_emulator: bool,
     system_contracts_path: &Path,
+    evm_emulator_path: Option<&Path>,
 ) -> BaseSystemContracts {
     let repo = system_contracts_repo(system_contracts_path);
     let bootloader_bytecode = match options {
@@ -294,6 +319,7 @@ fn playground(
         protocol_version,
         use_evm_emulator,
         system_contracts_path,
+        evm_emulator_path,
     )
 }
 
@@ -308,6 +334,7 @@ fn fee_estimate_contracts(
     protocol_version: ProtocolVersionId,
     use_evm_emulator: bool,
     system_contracts_path: &Path,
+    evm_emulator_path: Option<&Path>,
 ) -> BaseSystemContracts {
     let repo = system_contracts_repo(system_contracts_path);
     let bootloader_bytecode = match options {
@@ -328,6 +355,7 @@ fn fee_estimate_contracts(
         protocol_version,
         use_evm_emulator,
         system_contracts_path,
+        evm_emulator_path,
     )
 }
 
@@ -336,6 +364,7 @@ fn fee_estimate_impersonating_contracts(
     protocol_version: ProtocolVersionId,
     use_evm_emulator: bool,
     system_contracts_path: &Path,
+    evm_emulator_path: Option<&Path>,
 ) -> BaseSystemContracts {
     let repo = system_contracts_repo(system_contracts_path);
     let bootloader_bytecode = match options {
@@ -357,6 +386,7 @@ fn fee_estimate_impersonating_contracts(
         protocol_version,
         use_evm_emulator,
         system_contracts_path,
+        evm_emulator_path,
     )
 }
 
@@ -365,6 +395,7 @@ fn baseline_contracts(
     protocol_version: ProtocolVersionId,
     use_evm_emulator: bool,
     system_contracts_path: &Path,
+    evm_emulator_path: Option<&Path>,
 ) -> BaseSystemContracts {
     let repo = system_contracts_repo(system_contracts_path);
     let bootloader_bytecode = match options {
@@ -384,6 +415,7 @@ fn baseline_contracts(
         protocol_version,
         use_evm_emulator,
         system_contracts_path,
+        evm_emulator_path,
     )
 }
 
@@ -392,6 +424,7 @@ fn baseline_impersonating_contracts(
     protocol_version: ProtocolVersionId,
     use_evm_emulator: bool,
     system_contracts_path: &Path,
+    evm_emulator_path: Option<&Path>,
 ) -> BaseSystemContracts {
     let repo = system_contracts_repo(system_contracts_path);
     let bootloader_bytecode = match options {
@@ -412,11 +445,77 @@ fn baseline_impersonating_contracts(
         protocol_version,
         use_evm_emulator,
         system_contracts_path,
+        evm_emulator_path,
     )
+}
+
+/// Reads EVM emulator bytecode from a compiled artifact, so a locally built emulator can be
+/// paired with any choice of system contracts.
+fn read_evm_emulator_artifact(path: &Path) -> Vec<u8> {
+    let contents = std::fs::read(path)
+        .unwrap_or_else(|err| panic!("failed to read EVM emulator artifact {path:?}: {err}"));
+    bytecode_from_slice("EvmEmulator", &contents)
 }
 
 fn system_contracts_repo(root: &Path) -> SystemContractsRepo {
     SystemContractsRepo {
         root: root.to_path_buf(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use zksync_types::H256;
+
+    const TEST_VERSION: ProtocolVersionId = ProtocolVersionId::Version29;
+
+    fn artifact_with_bytecode(bytecode: &[u8]) -> tempfile::NamedTempFile {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        let artifact = serde_json::json!({ "bytecode": { "object": hex::encode(bytecode) } });
+        file.write_all(artifact.to_string().as_bytes()).unwrap();
+        file.flush().unwrap();
+        file
+    }
+
+    fn emulator_hash(evm_emulator_path: Option<PathBuf>) -> H256 {
+        SystemContracts::from_options(
+            SystemContractsOptions::BuiltIn,
+            None,
+            evm_emulator_path,
+            TEST_VERSION,
+            true,
+            ZKsyncOsConfig::default(),
+        )
+        .baseline_contracts
+        .evm_emulator
+        .expect("emulator is enabled")
+        .hash
+    }
+
+    #[test]
+    fn evm_emulator_path_is_read_from_the_artifact() {
+        let builtin = load_builtin_contract(TEST_VERSION, "EvmEmulator");
+        let artifact = artifact_with_bytecode(&builtin);
+        assert_eq!(
+            emulator_hash(Some(artifact.path().to_path_buf())),
+            emulator_hash(None),
+            "an artifact carrying the built-in bytecode should hash to the built-in emulator"
+        );
+    }
+
+    #[test]
+    fn evm_emulator_path_overrides_the_builtin_emulator() {
+        let mut bytecode = load_builtin_contract(TEST_VERSION, "EvmEmulator");
+        // Pad by whole words, and by an even number of them, to keep the length parity that
+        // EraVM bytecode hashing requires.
+        bytecode.extend_from_slice(&[0u8; 64]);
+        let artifact = artifact_with_bytecode(&bytecode);
+        assert_ne!(
+            emulator_hash(Some(artifact.path().to_path_buf())),
+            emulator_hash(None),
+            "--evm-emulator-path should take precedence over the built-in emulator"
+        );
     }
 }


### PR DESCRIPTION
Stacked on #779 — that fix is the first commit here, so review it first or merge it and I will rebase.

### Why

The emulator bytecode can only be chosen together with the rest of the system contracts: `built-in` takes both from the embedded archive, `local` takes both from disk. So testing a locally built emulator means switching *every* system contract to local as well, which only works while the contracts on disk match the protocol version of the pinned core.

In era-contracts that is not the case. Our `system-contracts` are on v32 while `main` pins `core-v29.0.0`, so `--dev-system-contracts=local` gets as far as genesis and then halts in the bootloader:

```
Assertion error: offset for L1Messenger is not 64
```

The practical effect is that the EVM emulator in era-contracts is covered by no test at all. `EvmEmulation.spec.ts` runs against the node's built-in emulator, so a change to the emulator in the repo is exercised by nothing until a release of this node happens to ship it.

### What

`--evm-emulator-path <PATH>` takes a compiled artifact and uses its bytecode for the emulator regardless of `--dev-system-contracts`, leaving the contract set alone.

### Evidence it does the job

Against a pending era-contracts change that adds memory-offset validation to the emulator, with built-in v29 contracts throughout and only the emulator swapped:

| emulator | result |
|---|---|
| built-in | 26 passing, **18 failing** |
| `--evm-emulator-path` → repo's `EvmEmulator.yul` | **44 passing, 0 failing** |

Same binary, same contracts, same specs. The 18 are precisely the cases the emulator change fixes, and the v32 emulator runs happily against v29 built-in contracts.

### Notes

Threaded alongside `system_contracts_path` through the config and the `SystemContracts` builder; the three in-crate `from_options` call sites pass the config value. Two unit tests cover it: an artifact carrying the built-in bytecode hashes to the built-in emulator, and a modified artifact takes precedence over built-in.

`cargo fmt` clean. `cargo clippy -p anvil_zksync_core --all-targets -- -D warnings` reports 3 `await_holding_lock` errors in `in_memory_inner.rs`; they reproduce unchanged on `main` and are untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)